### PR TITLE
[auto] [Issue #1] Implement dedup guard for cc-taskrunner

### DIFF
--- a/plugin/taskrunner.sh
+++ b/plugin/taskrunner.sh
@@ -103,7 +103,7 @@ if not queue:
 else:
     for t in queue:
         status = t.get('status', 'pending')
-        symbol = {'pending': '○', 'running': '▶', 'completed': '✓', 'failed': '✗'}.get(status, '?')
+        symbol = {'pending': '○', 'running': '▶', 'completed': '✓', 'failed': '✗', 'cancelled': '⊘'}.get(status, '?')
         print(f'{symbol} {t[\"id\"][:8]}  {status:10}  {t[\"title\"][:60]}')
 "
 }
@@ -111,13 +111,41 @@ else:
 fetch_next_task() {
   init_queue
   python3 -c "
-import json
+import json, re
+
 with open('$QUEUE_FILE') as f:
     queue = json.load(f)
+
+def extract_issue_refs(title):
+    \"\"\"Extract issue references like [Issue #123] or #123 from a task title.\"\"\"
+    refs = set()
+    # Match [Issue #N] pattern (case-insensitive)
+    for m in re.finditer(r'\[Issue\s+#(\d+)\]', title, re.IGNORECASE):
+        refs.add(int(m.group(1)))
+    return refs
+
+# Collect issue refs from running and recently completed tasks
+active_issue_refs = set()
 for t in queue:
-    if t.get('status') == 'pending':
-        print(json.dumps(t))
-        break
+    if t.get('status') in ('running', 'completed'):
+        active_issue_refs.update(extract_issue_refs(t.get('title', '')))
+
+# Find first pending task that doesn't duplicate an active issue
+for t in queue:
+    if t.get('status') != 'pending':
+        continue
+    task_refs = extract_issue_refs(t.get('title', ''))
+    if task_refs and task_refs & active_issue_refs:
+        # Duplicate detected — mark as cancelled
+        t['status'] = 'cancelled'
+        t['result'] = 'Skipped: duplicate of running/completed task for issue #' + ', #'.join(str(r) for r in sorted(task_refs & active_issue_refs))
+        with open('$QUEUE_FILE', 'w') as f:
+            json.dump(queue, f, indent=2)
+        import sys
+        print(f'[dedup] Skipping task {t[\"id\"][:8]}: duplicate issue ref', file=sys.stderr)
+        continue
+    print(json.dumps(t))
+    break
 else:
     print('')
 "

--- a/taskrunner.sh
+++ b/taskrunner.sh
@@ -102,7 +102,7 @@ if not queue:
 else:
     for t in queue:
         status = t.get('status', 'pending')
-        symbol = {'pending': '○', 'running': '▶', 'completed': '✓', 'failed': '✗'}.get(status, '?')
+        symbol = {'pending': '○', 'running': '▶', 'completed': '✓', 'failed': '✗', 'cancelled': '⊘'}.get(status, '?')
         print(f'{symbol} {t[\"id\"][:8]}  {status:10}  {t[\"title\"][:60]}')
 "
 }
@@ -110,13 +110,41 @@ else:
 fetch_next_task() {
   init_queue
   python3 -c "
-import json
+import json, re
+
 with open('$QUEUE_FILE') as f:
     queue = json.load(f)
+
+def extract_issue_refs(title):
+    \"\"\"Extract issue references like [Issue #123] or #123 from a task title.\"\"\"
+    refs = set()
+    # Match [Issue #N] pattern (case-insensitive)
+    for m in re.finditer(r'\[Issue\s+#(\d+)\]', title, re.IGNORECASE):
+        refs.add(int(m.group(1)))
+    return refs
+
+# Collect issue refs from running and recently completed tasks
+active_issue_refs = set()
 for t in queue:
-    if t.get('status') == 'pending':
-        print(json.dumps(t))
-        break
+    if t.get('status') in ('running', 'completed'):
+        active_issue_refs.update(extract_issue_refs(t.get('title', '')))
+
+# Find first pending task that doesn't duplicate an active issue
+for t in queue:
+    if t.get('status') != 'pending':
+        continue
+    task_refs = extract_issue_refs(t.get('title', ''))
+    if task_refs and task_refs & active_issue_refs:
+        # Duplicate detected — mark as cancelled
+        t['status'] = 'cancelled'
+        t['result'] = 'Skipped: duplicate of running/completed task for issue #' + ', #'.join(str(r) for r in sorted(task_refs & active_issue_refs))
+        with open('$QUEUE_FILE', 'w') as f:
+            json.dump(queue, f, indent=2)
+        import sys
+        print(f'[dedup] Skipping task {t[\"id\"][:8]}: duplicate issue ref', file=sys.stderr)
+        continue
+    print(json.dumps(t))
+    break
 else:
     print('')
 "


### PR DESCRIPTION
## Autonomous Task

**Task ID**: `70304239-bdef-40a4-9f0e-2d8601bb3736`
**Authority**: auto_safe
**Exit code**: 0

## Task Prompt
Fix GitHub issue #1: Dedup guard — skip tasks targeting same GitHub issue as running task.

Before the taskrunner picks up a pending task, it should check if there's already a running or recently completed task targeting the same GitHub issue. Match by extracting issue references from the task title (e.g. "[Issue #123]") and comparing against running/completed tasks.

If a duplicate is found, skip the task (leave it pending or mark it cancelled with a note). This prevents the issue-watcher from creating duplicate work when the same issue triggers multiple task creations.

Reference: https://github.com/Stackbilt-dev/cc-taskrunner/issues/1

The taskrunner is a bash script — check scripts/taskrunner.sh in the aegis-daemon repo for the current implementation pattern. The dedup logic should be added either in the taskrunner itself or as a pre-execution check in the API.

TASK_COMPLETE when done.

## Result Summary
Changes committed. Here's a summary of what was implemented:

**Dedup guard in `fetch_next_task()`** (both `taskrunner.sh` and `plugin/taskrunner.sh`):

1. **`extract_issue_refs(title)`** — extracts issue numbers from `[Issue #N]` patterns in task titles (case-insensitive)
2. **Collects active issue refs** — scans all `running` and `completed` tasks for issue references
3. **Skips duplicates** — if a pending task's issue refs overlap with active refs, it's marked `cancelled` with a descriptive note and skipped
4. **Status symbol** — added `⊘` for cancelled tasks in `list_tasks()`

The dedup is conservative: tasks without issue references in their title are never skipped. Only `[Issue #N]` patterns trigger matching.

TASK_COMPLETE

---
Generated by AEGIS task runner. Review before merging.