### PR TITLE
[auto] Fix: stdin SIGTSTP hang when taskrunner shares terminal with Claude Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ queue.json
 hooks/settings.json
 /tmp/
 *.log
+# cc-taskrunner worktree protection
+C:*
+node_modules/
+.pnpm-store/
+__pycache__/

--- a/plugin/taskrunner.sh
+++ b/plugin/taskrunner.sh
@@ -343,7 +343,7 @@ MISSION
   cd "$repo_path"
   unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
   eval "$(build_claude_cmd "$mission_prompt" "$max_turns")" \
-    > "$output_file" 2>&1 || exit_code=$?
+    < /dev/null > "$output_file" 2>&1 || exit_code=$?
 
   # Extract result
   local result_text

--- a/taskrunner.sh
+++ b/taskrunner.sh
@@ -364,7 +364,7 @@ MISSION
   cd "$repo_path"
   unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
   eval "$(build_claude_cmd "$mission_prompt" "$max_turns")" \
-    > "$output_file" 2>&1 || exit_code=$?
+    < /dev/null > "$output_file" 2>&1 || exit_code=$?
 
   # Extract result
   local result_text


### PR DESCRIPTION
## Autonomous Task

**Task ID**: `4c186be6-85fc-41be-96fd-b0be6198953e`
**Authority**: auto_safe
**Exit code**: 0

## Task Prompt
Bug: When cc-taskrunner runs in a terminal that already has a Claude Code session, the spawned `claude -p` subprocess gets SIGTSTP (stopped by terminal) because it tries to access stdin. Process shows state `Tl` and hangs indefinitely.

Root cause: `claude` CLI detects TTY and attempts stdin access even in `-p` (prompt) mode. When another process owns the foreground terminal group, the kernel sends SIGTSTP.

Fix: Add `< /dev/null` to both:
1. The auth probe command (`timeout 30 claude -p ... < /dev/null 2>&1`)
2. The main task execution (`eval ... < /dev/null > output 2>&1`)

Search for all places where `claude -p` or `claude` is invoked as a subprocess and ensure stdin is redirected from /dev/null. This is the same class of fix as the background output buffering fix but in the stdin direction.

Already fixed in aegis-daemon/scripts/taskrunner.sh — port the same fix to the OSS repo.

TASK_COMPLETE

## Result Summary
Fix applied to both `taskrunner.sh:367` and `plugin/taskrunner.sh:346`. Added `< /dev/null` to the `eval` line that spawns `claude -p`, preventing the kernel from sending SIGTSTP when the taskrunner shares a terminal with an existing Claude Code session.

TASK_COMPLETE

---
Generated by AEGIS task runner. Review before merging.