### PR TITLE
[auto] Add CLAUDE.md and .ai/ governance to cc-taskrunner

### DIFF
--- a/.ai/core.adf
+++ b/.ai/core.adf
@@ -1,0 +1,6 @@
+# Core Rules
+- This is a bash project — no TypeScript, no npm, no build step
+- Safety hooks in hooks/ are the critical path — changes require extra scrutiny
+- queue.json format must remain backward compatible
+- All bash should work on bash 4+ (no bashisms that break on older versions)
+- Python usage is limited to JSON manipulation — no pip dependencies

--- a/.ai/manifest.adf
+++ b/.ai/manifest.adf
@@ -1,0 +1,2 @@
+# cc-taskrunner ADF Manifest
+load core.adf always

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ C:*
 node_modules/
 .pnpm-store/
 __pycache__/
+# cc-taskrunner worktree protection
+C:*
+node_modules/
+.pnpm-store/
+__pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# cc-taskrunner
+
+Autonomous task queue for Claude Code with safety hooks, branch isolation, and PR creation.
+
+## Commands
+- `./taskrunner.sh` — Run until queue empty
+- `./taskrunner.sh --max N` — Run at most N tasks
+- `./taskrunner.sh --loop` — Loop forever (poll every 60s)
+- `./taskrunner.sh --dry-run` — Preview without executing
+- `./taskrunner.sh add "title"` — Add a task to the queue
+
+## Structure
+- `taskrunner.sh` — Main script (~580 lines bash + embedded python)
+- `hooks/` — Safety hook scripts (block-interactive, safety-gate, syntax-check, deploy)
+- `queue.json` — Task queue file (JSON array, gitignored; see queue.example.json)
+- `scripts/` — Helper scripts (deploy)
+- `plugin/` — Plugin system (agents, commands, safety)
+
+## Conventions
+- Bash 4+, Python 3 for JSON manipulation
+- All paths relative to script directory
+- Tasks use JSON format with id, title, repo, prompt, status fields
+- Completion signal: TASK_COMPLETE or TASK_BLOCKED


### PR DESCRIPTION
## Autonomous Task

**Task ID**: `59905130-1604-4329-91af-db0915b2a212`
**Authority**: auto_safe
**Exit code**: 0

## Task Prompt
## Problem
cc-taskrunner is a public OSS repo (Apache-2.0) but is missing CLAUDE.md and .ai/ governance files. As a repo that demonstrates autonomous AI execution, it should eat its own dogfood — having ADF governance is both good practice and agentic cred.

## What to Create

### 1. CLAUDE.md (project root)
Keep it concise — this is a bash project, not a TypeScript monorepo:
```markdown
# cc-taskrunner

Autonomous task queue for Claude Code with safety hooks, branch isolation, and PR creation.

## Commands
- `./taskrunner.sh` — Run until queue empty
- `./taskrunner.sh --max N` — Run at most N tasks
- `./taskrunner.sh --loop` — Loop forever (poll every 60s)
- `./taskrunner.sh --dry-run` — Preview without executing
- `./taskrunner.sh add "title"` — Add a task to the queue

## Structure
- `taskrunner.sh` — Main script (~600 lines bash + embedded python)
- `hooks/` — Safety hook scripts (block-interactive, safety-gate, syntax-check)
- `queue.json` — Task queue file (JSON array)
- `scripts/` — Helper scripts

## Conventions
- Bash 4+, Python 3 for JSON manipulation
- All paths relative to script directory
- Tasks use JSON format with id, title, repo, prompt, status fields
- Completion signal: TASK_COMPLETE or TASK_BLOCKED
```

### 2. .ai/manifest.adf
Minimal ADF manifest:
```
# cc-taskrunner ADF Manifest
load core.adf always
```

### 3. .ai/core.adf
```
# Core Rules
- This is a bash project — no TypeScript, no npm, no build step
- Safety hooks in hooks/ are the critical path — changes require extra scrutiny
- queue.json format must remain backward compatible
- All bash should work on bash 4+ (no bashisms that break on older versions)
- Python usage is limited to JSON manipulation — no pip dependencies
```

## Constraints
- Keep files minimal — this is a small project
- Don't over-engineer the ADF setup
- Make sure CLAUDE.md is accurate to the current codebase

Commit your work. TASK_COMPLETE when done.

## Result Summary
Committed. Three files created:
- **CLAUDE.md** — accurate to current codebase (~580 lines, hooks include deploy, plugin dir documented)
- **.ai/manifest.adf** — minimal manifest loading core.adf
- **.ai/core.adf** — core rules for the bash project

TASK_COMPLETE

---
Generated by AEGIS task runner. Review before merging.