### PR TITLE
fix: repo alias resolution and CC_REPOS_DIR support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+*.conf text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 queue.json
+repo-aliases.conf
 hooks/settings.json
 /tmp/
 *.log

--- a/plugin/taskrunner.sh
+++ b/plugin/taskrunner.sh
@@ -24,9 +24,20 @@ HOOKS_SETTINGS=""
 POLL_INTERVAL="${CC_POLL_INTERVAL:-60}"
 MAX_TASKS="${CC_MAX_TASKS:-0}"  # 0 = unlimited
 MAX_TURNS="${CC_MAX_TURNS:-25}"
+REPOS_DIR="${CC_REPOS_DIR:-}"  # Base directory for repo lookups
 DRY_RUN=false
 LOOP_MODE=false
 TASKS_RUN=0
+
+# ─── Repo aliases ───────────────────────────────────────────
+# Alias file: one "alias=directory" per line (e.g. smart_revenue_recovery=smart_revenue_recovery_adf)
+declare -A REPO_ALIASES
+if [[ -f "${CC_REPO_ALIASES:-${SCRIPT_DIR}/repo-aliases.conf}" ]]; then
+  while IFS='=' read -r key val; do
+    [[ -z "$key" || "$key" = "#"* ]] && continue
+    REPO_ALIASES["${key// /}"]="${val// /}"
+  done < "${CC_REPO_ALIASES:-${SCRIPT_DIR}/repo-aliases.conf}"
+fi
 
 # ─── Parse args ──────────────────────────────────────────────
 
@@ -252,14 +263,23 @@ execute_task() {
     return 0
   fi
 
-  # Resolve repo path
-  local repo_path
-  if [[ "$repo" == "." ]]; then
+  # Resolve repo path (supports aliases and CC_REPOS_DIR)
+  local repo_path resolved_name
+  resolved_name="${REPO_ALIASES[$repo]:-$repo}"
+  if [[ "$resolved_name" != "$repo" ]]; then
+    log "│  Alias: ${repo} → ${resolved_name}"
+  fi
+
+  if [[ "$resolved_name" == "." ]]; then
     repo_path="$(pwd)"
-  elif [[ -d "$repo" ]]; then
-    repo_path="$(cd "$repo" && pwd)"
+  elif [[ -d "$resolved_name" ]]; then
+    repo_path="$(cd "$resolved_name" && pwd)"
+  elif [[ -n "$REPOS_DIR" && -d "${REPOS_DIR}/${resolved_name}" ]]; then
+    repo_path="$(cd "${REPOS_DIR}/${resolved_name}" && pwd)"
+  elif [[ -n "$REPOS_DIR" && -d "${REPOS_DIR}/${repo}" ]]; then
+    repo_path="$(cd "${REPOS_DIR}/${repo}" && pwd)"
   else
-    err "Repo not found: ${repo}"
+    err "Repo not found: ${repo}${resolved_name:+ (resolved: ${resolved_name})}"
     update_task_status "$task_id" "failed" "Repo not found: ${repo}"
     return 1
   fi

--- a/repo-aliases.example.conf
+++ b/repo-aliases.example.conf
@@ -1,0 +1,7 @@
+# Repo alias configuration for cc-taskrunner
+# Format: task_repo_name=actual_directory_name
+# Lines starting with # are comments
+#
+# Example:
+# smart_revenue_recovery=smart_revenue_recovery_adf
+# kurtovermier.com=kurtosite092025

--- a/taskrunner.sh
+++ b/taskrunner.sh
@@ -30,9 +30,20 @@ HOOKS_SETTINGS="${HOOKS_DIR}/settings.json"
 POLL_INTERVAL="${CC_POLL_INTERVAL:-60}"
 MAX_TASKS="${CC_MAX_TASKS:-0}"  # 0 = unlimited
 MAX_TURNS="${CC_MAX_TURNS:-25}"
+REPOS_DIR="${CC_REPOS_DIR:-}"  # Base directory for repo lookups
 DRY_RUN=false
 LOOP_MODE=false
 TASKS_RUN=0
+
+# ─── Repo aliases ───────────────────────────────────────────
+# Alias file: one "alias=directory" per line (e.g. smart_revenue_recovery=smart_revenue_recovery_adf)
+declare -A REPO_ALIASES
+if [[ -f "${CC_REPO_ALIASES:-${SCRIPT_DIR}/repo-aliases.conf}" ]]; then
+  while IFS='=' read -r key val; do
+    [[ -z "$key" || "$key" = "#"* ]] && continue
+    REPO_ALIASES["${key// /}"]="${val// /}"
+  done < "${CC_REPO_ALIASES:-${SCRIPT_DIR}/repo-aliases.conf}"
+fi
 
 # ─── Parse args ──────────────────────────────────────────────
 
@@ -282,14 +293,23 @@ execute_task() {
     return 0
   fi
 
-  # Resolve repo path
-  local repo_path
-  if [[ "$repo" == "." ]]; then
+  # Resolve repo path (supports aliases and CC_REPOS_DIR)
+  local repo_path resolved_name
+  resolved_name="${REPO_ALIASES[$repo]:-$repo}"
+  if [[ "$resolved_name" != "$repo" ]]; then
+    log "│  Alias: ${repo} → ${resolved_name}"
+  fi
+
+  if [[ "$resolved_name" == "." ]]; then
     repo_path="$(pwd)"
-  elif [[ -d "$repo" ]]; then
-    repo_path="$(cd "$repo" && pwd)"
+  elif [[ -d "$resolved_name" ]]; then
+    repo_path="$(cd "$resolved_name" && pwd)"
+  elif [[ -n "$REPOS_DIR" && -d "${REPOS_DIR}/${resolved_name}" ]]; then
+    repo_path="$(cd "${REPOS_DIR}/${resolved_name}" && pwd)"
+  elif [[ -n "$REPOS_DIR" && -d "${REPOS_DIR}/${repo}" ]]; then
+    repo_path="$(cd "${REPOS_DIR}/${repo}" && pwd)"
   else
-    err "Repo not found: ${repo}"
+    err "Repo not found: ${repo}${resolved_name:+ (resolved: ${resolved_name})}"
     update_task_status "$task_id" "failed" "Repo not found: ${repo}"
     return 1
   fi


### PR DESCRIPTION
## Summary
- Adds `REPO_ALIASES` support loaded from `repo-aliases.conf` (configurable via `CC_REPO_ALIASES` env var) so tasks with aliased repo names resolve correctly at taskrunner claim time
- Adds `CC_REPOS_DIR` env var for configurable base directory for repo lookups
- Fixes CRLF line endings across all shell scripts and adds `.gitattributes` to prevent recurrence

Closes #11

## Details

The repo resolution order is now:
1. Check alias map (`repo-aliases.conf`) → resolve name
2. Try resolved name as direct path
3. Try `$CC_REPOS_DIR/resolved_name`
4. Try `$CC_REPOS_DIR/original_name`
5. Fail with descriptive error

**Note:** The server-side preflight validation in the AEGIS API that pre-fails tasks before the taskrunner claims them is a separate issue that needs to be addressed in the aegis-daemon repo. This PR fixes the taskrunner side so aliased repos work when tasks do reach it.

## Test plan
- [ ] Create `repo-aliases.conf` with an alias mapping, verify task resolves correctly
- [ ] Verify `CC_REPOS_DIR` resolution works for non-aliased repos
- [ ] Verify existing behavior unchanged when no alias file or repos dir is configured
- [ ] Verify `bash -n taskrunner.sh` passes (CRLF fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)