### PR TITLE
chore: add canonical SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security
+
+For the full Stackbilt security policy, see https://docs.stackbilt.dev/security/.
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+### How to report
+
+- **Primary channel:** email `admin@stackbilt.dev` with "SECURITY:" in the subject line
+- **GitHub Security Advisory:** https://github.com/Stackbilt-dev/cc-taskrunner/security/advisories/new
+- Include: vulnerability description, reproduction steps, potential impact, and any suggested mitigation
+
+### Response targets
+
+| Severity | Acknowledgement | Fix target |
+|---|---|---|
+| Critical — active exploitation, data exposure | 24 hours | 7 days |
+| High — exploitable with effort | 48 hours | 14 days |
+| Medium / Low | 5 business days | Next release cycle |
+
+These are targets, not contractual SLAs. Stackbilt is a solo-founder operation and response times reflect that reality honestly. Critical issues affecting user data are prioritized above everything else.
+
+### Scope
+
+This policy covers all software published in this repository. For the full policy covering the entire Stackbilt-dev organization, see the [canonical security policy](https://docs.stackbilt.dev/security/).
+
+### Out of scope
+
+- Denial of service against free-tier services (Cloudflare handles DDoS)
+- Rate limiting bypass on non-authenticated endpoints (unless it enables data access)
+- Missing security headers on non-production deployments
+- Vulnerabilities in third-party dependencies where this repo is not the upstream maintainer
+
+### Disclosure
+
+- Stackbilt practices **coordinated disclosure** with a minimum 90-day window (30 days for critical).
+- Reporters are credited in release notes unless anonymity is requested.
+- Good-faith security research within this policy will not face legal action.
+
+### Contact
+
+- **Primary:** admin@stackbilt.dev
+- **Canonical policy:** https://docs.stackbilt.dev/security/


### PR DESCRIPTION
## Summary

Adds the standardized Stackbilt-dev `SECURITY.md` to this repository. This is the canonical per-repo security reporting file being rolled out across the entire Stackbilt-dev organization, so every repository exposes the same reporting entry point, response SLAs, and scope definition.

## What this adds

- **Primary reporting channel**: `admin@stackbilt.dev` with `SECURITY:` subject prefix
- **GitHub Security Advisory link** scoped to this repo for coordinated disclosure
- **Response target matrix** — Critical: 24h ack / 7d fix; High: 48h / 14d; Medium/Low: 5 business days / next release
- **Explicit "no public GH issues for vulnerabilities" rule** — external researchers should not open public issues for security findings
- **Scope and out-of-scope** sections clarifying what's covered (e.g., DoS on free tier is explicitly out of scope — Cloudflare handles DDoS)
- **Coordinated disclosure terms** — 90-day window (30 days for critical), credit in release notes, no legal action against good-faith researchers
- **Link back to the canonical policy** at https://docs.stackbilt.dev/security/

## Why this matters

Every Stackbilt-dev repository should have a SECURITY.md so the GitHub security tab surfaces it automatically and external researchers have a clear, consistent reporting path. Without a per-repo file, researchers either open public issues (which is the wrong channel and leaks the vulnerability) or give up and don't report at all.

## Test plan

- [x] File renders correctly as markdown
- [x] All links resolve:
  - https://docs.stackbilt.dev/security/ (canonical policy, already live)
  - https://github.com/Stackbilt-dev/cc-taskrunner/security/advisories/new (per-repo GHSA endpoint)
  - `mailto:admin@stackbilt.dev` (primary channel)
- [x] File does not conflict with any existing `SECURITY.md` (none existed before this PR)
- [ ] Verify GitHub security tab picks up the file after merge

## Related

- Stackbilt-dev/docs#15 — Outbound disclosure policy PR where this template is defined as the canonical source
- Companion PRs landing in other Stackbilt-dev repositories as part of the same rollout

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)