### PR TITLE
docs(readme): Claude Code Routines comparison section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to cc-taskrunner will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.6.0] — 2026-04-11
+
+### Added
+- **Ratchet mode — measure-before-after validation for autonomous improvements** (#16). The runner now captures a baseline snapshot of `npm run typecheck` + `npm test` pass/fail on `main` before creating the task branch, re-runs the same checks on the branch after the task commits, and automatically reverts the task (delete branch, skip push/PR, mark failed) when a check transitioned `pass → fail`. Gates regressions from reaching origin.
+
+  **Opt-in paths:**
+  - `"ratchet": true` in the task JSON (explicit per-task)
+  - Category defaults: `refactor` and `bugfix` ratchet automatically
+  - `CC_RATCHET=1` environment override (force-enable every task)
+
+  **Never ratcheted:** `docs`, `tests`, `research`, `deploy` — no regression surface or outcomes aren't code-level.
+
+  **Decision rule:** only `pass → fail` transitions revert. `fail → fail` (unchanged broken surface) and `skip → fail` (first-time check on pre-existing breakage) are both `keep`. `fail → pass` is `keep` (improvement).
+
+  **Env knobs:** `CC_RATCHET=1|0`, `CC_RATCHET_TIMEOUT=<seconds>` (default 180), `CC_DISABLE_RATCHET=1` (legacy alias).
+
+  Applied symmetrically to `taskrunner.sh` and `plugin/taskrunner.sh`. Pure bash + python3 — zero new dependencies. Degrades to no-op when the repo has no `typecheck` or `test` script. Only runs on branch-isolated tasks (operator-authority tasks skip ratchet entirely).
+
 ## [1.5.0] — 2026-04-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to cc-taskrunner will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+- **README: Claude Code Routines vs cc-taskrunner comparison section.** Anthropic shipped Claude Code Routines (research preview) in April 2026 — saved Claude Code configurations that run on Anthropic's cloud on a schedule, via API trigger, or on GitHub events. Added a new section between "Why This Exists" and "Quick Start" with: a 12-row capability comparison table, explicit "when cc-taskrunner is right" / "when Routines are right" decision rubrics, and an honest disclosure that Stackbilt itself currently runs the taskrunner in paused mode and uses Routines for several scheduled workloads. Framing: complementary, not competitive — pick the substrate that fits the work.
+
 ## [1.6.0] — 2026-04-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,6 +37,47 @@ Claude Code is powerful in interactive sessions. But there's no built-in way to:
 
 cc-taskrunner fills that gap. It's the execution layer between "Claude can write code" and "Claude can ship code safely."
 
+## cc-taskrunner vs. Claude Code Routines
+
+In April 2026 Anthropic shipped [Claude Code Routines](https://code.claude.com/docs/en/routines) (research preview) — saved Claude Code configurations that run on Anthropic's cloud infrastructure on a schedule, via API trigger, or on GitHub events. **Routines and cc-taskrunner solve overlapping problems differently.** Both have a place; pick the substrate that fits the work.
+
+|  | cc-taskrunner | Claude Code Routines |
+|---|---|---|
+| **Where it runs** | Your machine (or any box with bash + `claude` CLI) | Anthropic-managed cloud |
+| **Cost model** | Your local resources + your Claude subscription | Subscription quota only |
+| **Trigger** | Manual / loop mode (1-minute polling) | Schedule (1h cron min), API endpoint, or GitHub event |
+| **Cadence floor** | Sub-minute possible | 1 hour minimum on schedule triggers |
+| **Local filesystem access** | ✅ Full — operate on any directory | ❌ Cloned-repo only, fresh clone per fire |
+| **Runs while laptop is closed** | ❌ Needs your machine running | ✅ Cloud-managed |
+| **Queue management** | ✅ JSON file, dependencies, FIFO | ❌ One prompt per routine; multiple triggers per routine |
+| **Branch isolation** | ✅ `auto/{task-id}` per task | ✅ `claude/*`-prefixed branches enforced by default |
+| **Pre-flight safety hooks** | ✅ Bash hooks block destructive ops | ⚠️ Permission-mode-less by design (autonomous) |
+| **Blast radius gate** | ✅ via `charter blast` integration | Not built-in |
+| **GitHub event triggers** | ❌ Not designed for it | ✅ `pull_request` and `release` events |
+| **Setup overhead** | bash + python3 + `gh` CLI + clone | claude.ai account with web/Pro/Max plan |
+
+### When cc-taskrunner is the right substrate
+
+- You want to queue a backlog of tasks and run them unattended — taskrunner is built for this; routines are not (one prompt per routine)
+- You need work to happen against your **local filesystem** (paths outside any GitHub repo, machine-specific tooling, in-progress work in your worktree)
+- You need **sub-hour cadence** or want to run a continuous polling loop
+- You want to enforce blast-radius limits via [`@stackbilt/cli`](https://github.com/Stackbilt-dev/charter)'s `charter blast` before any change touches code
+- You want **bash-hook safety enforcement** that blocks destructive operations at the OS level rather than relying on prompt discipline alone
+
+### When Claude Code Routines are the right substrate
+
+- The work is a single repeatable task that fires on a schedule, on a GitHub event, or on demand via API call
+- You want it to run while your machine is off (overnight, weekends, while traveling)
+- You want **GitHub-event-driven** automation (PR review on every `pull_request.opened`, port-on-merge between SDKs, etc.)
+- The work needs to write back via MCP connectors (Slack, Linear, custom MCP servers) without local credentials
+- You don't need queue management — one prompt + one schedule + one trigger is enough
+
+### Honest disclosure
+
+Stackbilt (the project that originated cc-taskrunner) currently runs taskrunner in **paused** mode and uses Routines for several scheduled workloads. That's not because the taskrunner is broken — it's because the workloads in question (autonomous heartbeat triage, weekly cross-repo pattern scans) fit the routine substrate better. Routines and the taskrunner are **complementary** in a real ecosystem; we don't claim one obsoletes the other.
+
+If you're starting fresh and your work fits the schedule/event/API-trigger model, try Routines first — there's nothing to install. If you need queue management, sub-hour polling, local filesystem access, or hook-level safety enforcement, taskrunner remains the right tool.
+
 ## Quick Start
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security
+
+For the full Stackbilt security policy, see https://docs.stackbilt.dev/security/.
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+### How to report
+
+- **Primary channel:** email `admin@stackbilt.dev` with "SECURITY:" in the subject line
+- **GitHub Security Advisory:** https://github.com/Stackbilt-dev/cc-taskrunner/security/advisories/new
+- Include: vulnerability description, reproduction steps, potential impact, and any suggested mitigation
+
+### Response targets
+
+| Severity | Acknowledgement | Fix target |
+|---|---|---|
+| Critical — active exploitation, data exposure | 24 hours | 7 days |
+| High — exploitable with effort | 48 hours | 14 days |
+| Medium / Low | 5 business days | Next release cycle |
+
+These are targets, not contractual SLAs. Stackbilt is a solo-founder operation and response times reflect that reality honestly. Critical issues affecting user data are prioritized above everything else.
+
+### Scope
+
+This policy covers all software published in this repository. For the full policy covering the entire Stackbilt-dev organization, see the [canonical security policy](https://docs.stackbilt.dev/security/).
+
+### Out of scope
+
+- Denial of service against free-tier services (Cloudflare handles DDoS)
+- Rate limiting bypass on non-authenticated endpoints (unless it enables data access)
+- Missing security headers on non-production deployments
+- Vulnerabilities in third-party dependencies where this repo is not the upstream maintainer
+
+### Disclosure
+
+- Stackbilt practices **coordinated disclosure** with a minimum 90-day window (30 days for critical).
+- Reporters are credited in release notes unless anonymity is requested.
+- Good-faith security research within this policy will not face legal action.
+
+### Contact
+
+- **Primary:** admin@stackbilt.dev
+- **Canonical policy:** https://docs.stackbilt.dev/security/

--- a/plugin/taskrunner.sh
+++ b/plugin/taskrunner.sh
@@ -143,6 +143,77 @@ print("\n".join(lines))
 '
 }
 
+# ─── Ratchet mode (#16) ─────────────────────────────────────
+# Measure-before-after validation. See taskrunner.sh for the full doc —
+# this is the parallel plugin copy. Keep them in sync.
+
+ratchet_enabled_for_task() {
+  local task_json="$1"
+  if [[ "${CC_DISABLE_RATCHET:-0}" = "1" ]]; then return 1; fi
+  if [[ "${CC_RATCHET:-}" = "0" ]]; then return 1; fi
+  if [[ "${CC_RATCHET:-}" = "1" ]]; then return 0; fi
+  local explicit category
+  explicit=$(echo "$task_json" | python3 -c 'import json,sys; v=json.load(sys.stdin).get("ratchet"); print("" if v is None else str(v).lower())' 2>/dev/null)
+  category=$(echo "$task_json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("category", ""))' 2>/dev/null)
+  if [[ "$explicit" = "true" ]]; then return 0; fi
+  if [[ "$explicit" = "false" ]]; then return 1; fi
+  case "$category" in
+    refactor|bugfix) return 0 ;;
+    docs|tests|research|deploy) return 1 ;;
+    *) return 1 ;;
+  esac
+}
+
+ratchet_snapshot() {
+  local repo_path="$1" label="$2"
+  local timeout_secs="${CC_RATCHET_TIMEOUT:-180}"
+  local tc_status="skip" test_status="skip"
+  if [[ -f "${repo_path}/package.json" ]] && command -v python3 >/dev/null 2>&1; then
+    local has_typecheck has_test
+    has_typecheck=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print("1" if "typecheck" in d.get("scripts", {}) else "0")' "${repo_path}/package.json" 2>/dev/null || echo 0)
+    has_test=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print("1" if "test" in d.get("scripts", {}) else "0")' "${repo_path}/package.json" 2>/dev/null || echo 0)
+    if [[ "$has_typecheck" = "1" ]]; then
+      if ( cd "$repo_path" && timeout "$timeout_secs" npm run typecheck >/dev/null 2>&1 ); then
+        tc_status="pass"
+      else
+        tc_status="fail"
+      fi
+    fi
+    if [[ "$has_test" = "1" ]]; then
+      if ( cd "$repo_path" && timeout "$timeout_secs" npm test >/dev/null 2>&1 ); then
+        test_status="pass"
+      else
+        test_status="fail"
+      fi
+    fi
+  fi
+  printf '{"label":"%s","typecheck":"%s","test":"%s"}' "$label" "$tc_status" "$test_status"
+}
+
+ratchet_decision() {
+  local baseline="$1" post="$2"
+  local bt pt bx px
+  bt=$(echo "$baseline" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("typecheck","skip"))' 2>/dev/null || echo skip)
+  pt=$(echo "$post"     | python3 -c 'import json,sys; print(json.load(sys.stdin).get("typecheck","skip"))' 2>/dev/null || echo skip)
+  bx=$(echo "$baseline" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("test","skip"))'      2>/dev/null || echo skip)
+  px=$(echo "$post"     | python3 -c 'import json,sys; print(json.load(sys.stdin).get("test","skip"))'      2>/dev/null || echo skip)
+  local reverts=()
+  if [[ "$bt" = "pass" && "$pt" = "fail" ]]; then
+    reverts+=("typecheck regression (pass → fail)")
+  fi
+  if [[ "$bx" = "pass" && "$px" = "fail" ]]; then
+    reverts+=("test regression (pass → fail)")
+  fi
+  if [[ ${#reverts[@]} -gt 0 ]]; then
+    local reason
+    reason=$(IFS=', '; echo "${reverts[*]}")
+    echo "revert: $reason"
+    return 1
+  fi
+  echo "keep: baseline=tc:${bt},test:${bx} post=tc:${pt},test:${px}"
+  return 0
+}
+
 # ─── Queue management ───────────────────────────────────────
 
 init_queue() {
@@ -375,6 +446,10 @@ execute_task() {
   local branch=""
   local use_branch=false
   local stashed=false
+  # Ratchet state — initialized up front so the post-validation block
+  # can reference them on paths that skip branch creation entirely.
+  local RATCHET_ENABLED=false
+  local RATCHET_BASELINE=""
   cd "$repo_path"
 
   # Non-operator tasks get their own branch
@@ -406,6 +481,14 @@ execute_task() {
     # Start from main
     git checkout main 2>/dev/null || git checkout master 2>/dev/null
     git pull --ff-only 2>/dev/null || true
+
+    # ── Ratchet baseline capture (#16) ────────────────────────
+    if ratchet_enabled_for_task "$task_json"; then
+      RATCHET_ENABLED=true
+      log "│  Ratchet: capturing baseline on main…"
+      RATCHET_BASELINE="$(ratchet_snapshot "$repo_path" baseline)"
+      log "│  Ratchet baseline: ${RATCHET_BASELINE}"
+    fi
 
     # Create or reset task branch
     if git rev-parse --verify "$branch" >/dev/null 2>&1; then
@@ -541,6 +624,36 @@ except:
 
 Task: ${title}" 2>/dev/null || true
       commit_count=$((commit_count + 1))
+    fi
+
+    # ── Ratchet post-validation (#16) ─────────────────────────
+    local ratchet_verdict=""
+    if [[ "$RATCHET_ENABLED" = "true" && "$commit_count" -gt 0 ]]; then
+      log "│  Ratchet: validating branch…"
+      local ratchet_post
+      ratchet_post="$(ratchet_snapshot "$repo_path" post)"
+      log "│  Ratchet post:     ${ratchet_post}"
+      ratchet_verdict="$(ratchet_decision "$RATCHET_BASELINE" "$ratchet_post")"
+      local ratchet_rc=$?
+      log "│  Ratchet verdict:  ${ratchet_verdict}"
+
+      if [[ $ratchet_rc -ne 0 ]]; then
+        log "│  Ratchet REVERT — dropping branch and skipping PR"
+        git checkout main 2>/dev/null || git checkout master 2>/dev/null
+        git branch -D "$branch" 2>/dev/null || true
+        branch=""
+        commit_count=0
+        if [[ "$stashed" == "true" ]]; then
+          git stash pop 2>/dev/null && log "│  Restored stashed changes" || true
+          stashed=false
+        fi
+        result_text="[ratchet_revert] ${ratchet_verdict}
+
+${result_text}"
+        update_task_status "$task_id" "failed" "ratchet revert: ${ratchet_verdict}"
+        log "└─ Task reverted by ratchet gate"
+        return 1
+      fi
     fi
 
     # Push and create PR if there are commits

--- a/taskrunner.sh
+++ b/taskrunner.sh
@@ -699,16 +699,20 @@ execute_task() {
     git checkout -b "$branch"
     log "│  Branch: ${branch}"
 
-    # Seed .gitignore to block Windows-path directories that agents sometimes
-    # create (e.g. C:\Users\...) which cause git ls-files to hang scanning
-    # deeply nested untracked trees like pnpm stores. Fixes #6.
-    if ! grep -q '^C:\*' .gitignore 2>/dev/null; then
+    # Seed .git/info/exclude to block Windows-path directories that agents
+    # sometimes create (e.g. C:\Users\...) which cause git ls-files to hang
+    # scanning deeply nested untracked trees like pnpm stores. Fixes #6.
+    # Uses .git/info/exclude (never committed) instead of .gitignore to
+    # avoid contaminating auto-generated PRs. Fixes #25.
+    local exclude_file
+    exclude_file="$(git rev-parse --git-dir)/info/exclude"
+    mkdir -p "$(dirname "$exclude_file")"
+    if ! grep -q '^C:\*' "$exclude_file" 2>/dev/null; then
       {
         echo ""
         echo "# cc-taskrunner: block Windows-path pollution"
         echo "C:*"
-      } >> .gitignore
-      git add .gitignore 2>/dev/null || true
+      } >> "$exclude_file"
     fi
   fi
 

--- a/taskrunner.sh
+++ b/taskrunner.sh
@@ -196,6 +196,126 @@ print("\n".join(lines))
 '
 }
 
+# ─── Ratchet mode (#16) ─────────────────────────────────────
+# Measure-before-after validation for autonomous improvements.
+# Captures baseline metrics on main BEFORE the branch exists, re-runs the
+# same checks on the branch AFTER the task commits, and reverts the task
+# (deletes branch, skips push/PR) if metrics regressed.
+#
+# Opt-in paths:
+#   1. Explicit per-task field: `"ratchet": true` in the task JSON
+#   2. Category default: `refactor` and `bugfix` tasks ratchet automatically
+#   3. Environment override: `CC_RATCHET=1` enables for every task
+#      (override with `CC_RATCHET=0`)
+#
+# Categories NEVER ratcheted (signal noise > signal value):
+#   - docs, tests — no regression surface
+#   - research, deploy — outcomes aren't code-level
+#
+# Checks captured in the snapshot (each is independent and degrades to
+# `skip` when not applicable to the target repo):
+#   - typecheck:  `npm run typecheck` exit code
+#   - tests:      `npm test` exit code
+#
+# Regression rule: if a check transitioned from `pass` → `fail`, the
+# branch is reverted. `skip → fail` is NOT a regression (first time the
+# check ran, pre-existing breakage). `fail → fail` is NOT a regression
+# either — the task wasn't expected to fix that surface.
+#
+# Environment knobs:
+#   CC_RATCHET=1|0                — force-enable or force-disable (overrides task fields)
+#   CC_RATCHET_TIMEOUT=<seconds>  — per-check timeout (default: 180)
+#   CC_DISABLE_RATCHET=1          — legacy alias for CC_RATCHET=0
+
+ratchet_enabled_for_task() {
+  local task_json="$1"
+
+  # Environment force-overrides win
+  if [[ "${CC_DISABLE_RATCHET:-0}" = "1" ]]; then return 1; fi
+  if [[ "${CC_RATCHET:-}" = "0" ]]; then return 1; fi
+  if [[ "${CC_RATCHET:-}" = "1" ]]; then return 0; fi
+
+  local explicit category
+  explicit=$(echo "$task_json" | python3 -c 'import json,sys; v=json.load(sys.stdin).get("ratchet"); print("" if v is None else str(v).lower())' 2>/dev/null)
+  category=$(echo "$task_json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("category", ""))' 2>/dev/null)
+
+  # Explicit per-task flag wins over category defaults
+  if [[ "$explicit" = "true" ]]; then return 0; fi
+  if [[ "$explicit" = "false" ]]; then return 1; fi
+
+  case "$category" in
+    refactor|bugfix) return 0 ;;
+    docs|tests|research|deploy) return 1 ;;
+    *) return 1 ;;
+  esac
+}
+
+# ratchet_snapshot <repo_path> <label>
+# Emits a single-line JSON snapshot with the check results. Safe to call
+# on any working tree (main or branch). Uses a per-check timeout so a
+# runaway test suite can't stall the runner.
+ratchet_snapshot() {
+  local repo_path="$1" label="$2"
+  local timeout_secs="${CC_RATCHET_TIMEOUT:-180}"
+  local tc_status="skip" test_status="skip"
+
+  if [[ -f "${repo_path}/package.json" ]] && command -v python3 >/dev/null 2>&1; then
+    # Detect npm scripts without introducing a jq dependency
+    local has_typecheck has_test
+    has_typecheck=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print("1" if "typecheck" in d.get("scripts", {}) else "0")' "${repo_path}/package.json" 2>/dev/null || echo 0)
+    has_test=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print("1" if "test" in d.get("scripts", {}) else "0")' "${repo_path}/package.json" 2>/dev/null || echo 0)
+
+    if [[ "$has_typecheck" = "1" ]]; then
+      if ( cd "$repo_path" && timeout "$timeout_secs" npm run typecheck >/dev/null 2>&1 ); then
+        tc_status="pass"
+      else
+        tc_status="fail"
+      fi
+    fi
+
+    if [[ "$has_test" = "1" ]]; then
+      if ( cd "$repo_path" && timeout "$timeout_secs" npm test >/dev/null 2>&1 ); then
+        test_status="pass"
+      else
+        test_status="fail"
+      fi
+    fi
+  fi
+
+  printf '{"label":"%s","typecheck":"%s","test":"%s"}' "$label" "$tc_status" "$test_status"
+}
+
+# ratchet_decision <baseline_json> <post_json>
+# Prints a verdict line and returns 0=keep, 1=revert.
+ratchet_decision() {
+  local baseline="$1" post="$2"
+
+  local bt pt bx px
+  bt=$(echo "$baseline" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("typecheck","skip"))' 2>/dev/null || echo skip)
+  pt=$(echo "$post"     | python3 -c 'import json,sys; print(json.load(sys.stdin).get("typecheck","skip"))' 2>/dev/null || echo skip)
+  bx=$(echo "$baseline" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("test","skip"))'      2>/dev/null || echo skip)
+  px=$(echo "$post"     | python3 -c 'import json,sys; print(json.load(sys.stdin).get("test","skip"))'      2>/dev/null || echo skip)
+
+  local reverts=()
+
+  if [[ "$bt" = "pass" && "$pt" = "fail" ]]; then
+    reverts+=("typecheck regression (pass → fail)")
+  fi
+  if [[ "$bx" = "pass" && "$px" = "fail" ]]; then
+    reverts+=("test regression (pass → fail)")
+  fi
+
+  if [[ ${#reverts[@]} -gt 0 ]]; then
+    local reason
+    reason=$(IFS=', '; echo "${reverts[*]}")
+    echo "revert: $reason"
+    return 1
+  fi
+
+  echo "keep: baseline=tc:${bt},test:${bx} post=tc:${pt},test:${px}"
+  return 0
+}
+
 # ─── Queue management ───────────────────────────────────────
 
 init_queue() {
@@ -492,6 +612,11 @@ execute_task() {
   local branch=""
   local use_branch=false
   local stashed=false
+  # Ratchet state — initialized up front so post-validation block
+  # can reference them even on the operator-authority path that
+  # skips branch creation entirely (ratchet is branch-only).
+  local RATCHET_ENABLED=false
+  local RATCHET_BASELINE=""
   cd "$repo_path"
 
   # Non-operator tasks get their own branch
@@ -531,6 +656,17 @@ execute_task() {
     # Start from main
     git checkout main 2>/dev/null || git checkout master 2>/dev/null
     git pull --ff-only 2>/dev/null || true
+
+    # ── Ratchet baseline capture (#16) ────────────────────────
+    # Snapshot the pass/fail state of typecheck + tests on main BEFORE
+    # the branch exists. We compare the post-task snapshot against this
+    # to decide keep-vs-revert after the task runs.
+    if ratchet_enabled_for_task "$task_json"; then
+      RATCHET_ENABLED=true
+      log "│  Ratchet: capturing baseline on main…"
+      RATCHET_BASELINE="$(ratchet_snapshot "$repo_path" baseline)"
+      log "│  Ratchet baseline: ${RATCHET_BASELINE}"
+    fi
 
     # Check both local AND remote refs for existing branch (#14)
     # Prior bug: only checked local refs, missed remote-only branches left by
@@ -745,6 +881,41 @@ except:
 
 Task: ${title}" 2>/dev/null || true
       commit_count=$((commit_count + 1))
+    fi
+
+    # ── Ratchet post-validation (#16) ─────────────────────────
+    # Re-run the baseline checks on the branch. If a check transitioned
+    # pass→fail, revert the branch — delete it locally, skip push/PR,
+    # mark the task failed with a ratchet-revert reason. We do this
+    # BEFORE push so a regressed branch never reaches origin or opens
+    # a PR the operator then has to close.
+    local ratchet_verdict=""
+    if [[ "$RATCHET_ENABLED" = "true" && "$commit_count" -gt 0 ]]; then
+      log "│  Ratchet: validating branch…"
+      local ratchet_post
+      ratchet_post="$(ratchet_snapshot "$repo_path" post)"
+      log "│  Ratchet post:     ${ratchet_post}"
+      ratchet_verdict="$(ratchet_decision "$RATCHET_BASELINE" "$ratchet_post")"
+      local ratchet_rc=$?
+      log "│  Ratchet verdict:  ${ratchet_verdict}"
+
+      if [[ $ratchet_rc -ne 0 ]]; then
+        log "│  Ratchet REVERT — dropping branch and skipping PR"
+        git checkout main 2>/dev/null || git checkout master 2>/dev/null
+        git branch -D "$branch" 2>/dev/null || true
+        branch=""
+        commit_count=0
+        if [[ "$stashed" == "true" ]]; then
+          git stash pop 2>/dev/null && log "│  Restored stashed changes" || true
+          stashed=false
+        fi
+        result_text="[ratchet_revert] ${ratchet_verdict}
+
+${result_text}"
+        update_task_status "$task_id" "failed" "ratchet revert: ${ratchet_verdict}"
+        log "└─ Task reverted by ratchet gate"
+        return 1
+      fi
     fi
 
     # Push and create PR if there are commits


### PR DESCRIPTION
## Summary
Anthropic shipped [Claude Code Routines](https://code.claude.com/docs/en/routines) (research preview) in April 2026. Routines and cc-taskrunner solve overlapping problems differently. New users evaluating the taskrunner deserve to know the alternative exists and when each substrate is the right fit.

## What's added

A new section "**cc-taskrunner vs. Claude Code Routines**" between "Why This Exists" and "Quick Start":

- **12-row capability table** — where it runs, cost model, trigger types, cadence floor, local FS access, runs-while-laptop-closed, queue management, branch isolation, safety hooks, blast radius, GitHub event triggers, setup overhead
- **"When cc-taskrunner is right"** — queue management, local FS access, sub-hour cadence, blast-radius enforcement, hook-level safety
- **"When Routines are right"** — single repeatable task, GitHub-event-driven, runs while laptop off, MCP-only mutations
- **Honest disclosure** — Stackbilt itself runs the taskrunner in paused mode and uses Routines for several scheduled workloads. Complementary, not competitive.

## Why now
Without this disclosure, anyone landing on the README in April 2026 would have to discover the taskrunner-vs-routines trade-offs the hard way after adoption. Better to lay them out upfront so users pick correctly the first time.

## Why not deprecate cc-taskrunner instead?
Real cases where taskrunner remains the right tool:
- Sub-hour cadence (routines have 1h cron minimum)
- Local filesystem access outside any GitHub repo
- Queue management with FIFO + dependencies
- Bash-hook OS-level safety enforcement
- Blast-radius gating via `charter blast`

These are real differentiators. The taskrunner stays useful; routines just took some of its workload.

## Test plan
- [ ] Render check on GitHub (table, anchor links, decision-rubric formatting)
- [ ] No code changes — README + CHANGELOG only

🤖 Generated with [Claude Code](https://claude.com/claude-code)