### PR TITLE
feat(ratchet): flip to opt-out by default + orphan branch cleanup (#26, #29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Workers AI executor now defaults to GLM-5.2 via `@stackbilt/llm-providers`.** The Cloudflare-native taskrunner package uses `@cf/zai-org/glm-5.2` as its primary model, falls back to Llama 4 Scout, and requires `@stackbilt/llm-providers >=1.18.0` so model catalog validation recognizes the GLM-5.2 Workers AI model.
 - **README: Claude Code Routines vs cc-taskrunner comparison section.** Anthropic shipped Claude Code Routines (research preview) in April 2026 — saved Claude Code configurations that run on Anthropic's cloud on a schedule, via API trigger, or on GitHub events. Added a new section between "Why This Exists" and "Quick Start" with: a 12-row capability comparison table, explicit "when cc-taskrunner is right" / "when Routines are right" decision rubrics, and an honest disclosure that Stackbilt itself currently runs the taskrunner in paused mode and uses Routines for several scheduled workloads. Framing: complementary, not competitive — pick the substrate that fits the work.
 
 ## [1.6.0] — 2026-04-11

--- a/README.md
+++ b/README.md
@@ -311,11 +311,13 @@ Once a human approves, cc-taskrunner picks up the job via the D1 bridge (see iss
 
 ## Alternative Execution Backends
 
-cc-taskrunner uses the `claude` CLI (`claude -p`) for all task execution. Two Stackbilt alternatives are in development:
+The local shell runner uses the `claude` CLI (`claude -p`) for repo/file-editing execution. Stackbilt also maintains Cloudflare-native execution paths for tasks where the LLM output is the deliverable:
 
 **llm-gateway** ([Stackbilt-dev/llm-gateway](https://github.com/Stackbilt-dev/llm-gateway)) — local proxy that sits between `claude -p` and upstream providers. Routes by cognitive load: planning/code turns → Groq, tool_loop turns → Anthropic. Zero changes to cc-taskrunner required — just set `ANTHROPIC_BASE_URL` to the gateway. Run shadow mode first to see projected savings per session.
 
-**llm-providers** ([Stackbilt-dev/llm-providers](https://github.com/Stackbilt-dev/llm-providers)) — Workers-native direct API abstraction. A future re-architecture path that would remove the `claude` CLI dependency entirely. More control, more work. Appropriate if cc-taskrunner needs to run in a Workers/edge environment without a local machine.
+**@stackbilt/workers-ai-taskrunner** (`workers-ai/`) — Cloudflare-native executor for D1-backed `cc_tasks` where the LLM output is the deliverable. It replaces the local `claude -p` execution call with `@stackbilt/llm-providers` routing through the Workers AI binding. The default primary model is Workers AI GLM-5.2 (`@cf/zai-org/glm-5.2`) with Llama 4 Scout fallback. Use this for research, analysis, content generation, and wiki/update tasks that do not need shell, git, or local filesystem access.
+
+**llm-providers** ([Stackbilt-dev/llm-providers](https://github.com/Stackbilt-dev/llm-providers)) — Workers-native direct API abstraction used by the Workers AI executor. It owns Cloudflare model catalog validation, response normalization, usage accounting, and provider resiliency.
 
 Note: Anthropic policy change (2026-04-05) bills programmatic `claude -p` use at API rates rather than subscription rates. Budget accordingly or use llm-gateway to reduce Anthropic turn count.
 

--- a/scripts/cleanup-branches.sh
+++ b/scripts/cleanup-branches.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# cleanup-branches.sh — Remove orphaned auto/ branches whose tasks are completed
+#
+# Branches created by cc-taskrunner follow the pattern:
+#   auto/{category}/{task-id-prefix}   (current format)
+#   auto/{task-id-prefix}              (legacy format)
+#
+# A branch is considered orphaned when its corresponding task in queue.json
+# has status "completed".  Dry-run by default; pass --execute to delete.
+#
+# Usage:
+#   ./scripts/cleanup-branches.sh [options]
+#
+# Options:
+#   --repo  <path>  Git repo to scan (default: current directory)
+#   --queue <file>  Path to queue.json (default: ../queue.json relative to this script)
+#   --execute       Actually delete branches; omit for dry-run
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+QUEUE_FILE="${CC_QUEUE_FILE:-${SCRIPT_DIR}/../queue.json}"
+REPO_PATH="$(pwd)"
+EXECUTE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)    REPO_PATH="$2"; shift 2 ;;
+    --queue)   QUEUE_FILE="$2"; shift 2 ;;
+    --execute) EXECUTE=true; shift ;;
+    *)         echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+REPO_PATH="$(cd "$REPO_PATH" && pwd)"
+
+if [[ ! -f "$QUEUE_FILE" ]]; then
+  echo "Queue file not found: ${QUEUE_FILE}" >&2
+  exit 1
+fi
+
+if ! git -C "$REPO_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Not a git repository: ${REPO_PATH}" >&2
+  exit 1
+fi
+
+# Collect 8-char prefixes of completed tasks
+completed_prefixes=$(python3 -c '
+import json, sys
+with open(sys.argv[1]) as f:
+    queue = json.load(f)
+for t in queue:
+    if t.get("status") == "completed":
+        print(t["id"][:8])
+' "$QUEUE_FILE")
+
+if [[ -z "$completed_prefixes" ]]; then
+  echo "No completed tasks in ${QUEUE_FILE}."
+  exit 0
+fi
+
+echo "Completed task prefixes:"
+while IFS= read -r prefix; do
+  echo "  ${prefix}"
+done <<< "$completed_prefixes"
+echo ""
+
+# Fetch to get current remote branch state
+git -C "$REPO_PATH" fetch origin --prune --quiet 2>/dev/null || true
+
+# Enumerate all auto/ branches (local + remote, deduplicated)
+local_branches=$(git -C "$REPO_PATH" branch --list 'auto/*' 2>/dev/null | sed 's/^[* ]*//' || true)
+remote_branches=$(git -C "$REPO_PATH" branch -r --list 'origin/auto/*' 2>/dev/null | sed 's|^[* ]*origin/||' || true)
+all_branches=$(printf "%s\n%s" "$local_branches" "$remote_branches" | sort -u | grep -v '^$' || true)
+
+if [[ -z "$all_branches" ]]; then
+  echo "No auto/ branches found in ${REPO_PATH}."
+  exit 0
+fi
+
+orphan_count=0
+
+while IFS= read -r branch; do
+  [[ -z "$branch" ]] && continue
+
+  # Extract the task prefix from branch name.
+  # Handles both auto/{task-id} and auto/{category}/{task-id}.
+  branch_tail="${branch##*/}"   # last path segment = task-id prefix
+
+  matched=false
+  while IFS= read -r prefix; do
+    [[ -z "$prefix" ]] && continue
+    if [[ "$branch_tail" == "$prefix" ]]; then
+      matched=true
+      break
+    fi
+  done <<< "$completed_prefixes"
+
+  if $matched; then
+    orphan_count=$((orphan_count + 1))
+    if $EXECUTE; then
+      echo "  [DELETE] ${branch}"
+      if git -C "$REPO_PATH" rev-parse --verify "refs/heads/${branch}" >/dev/null 2>&1; then
+        git -C "$REPO_PATH" branch -d "$branch" 2>/dev/null || \
+          git -C "$REPO_PATH" branch -D "$branch" 2>/dev/null || true
+      fi
+      if git -C "$REPO_PATH" show-ref --verify --quiet "refs/remotes/origin/${branch}" 2>/dev/null; then
+        git -C "$REPO_PATH" push origin --delete "$branch" 2>/dev/null || true
+      fi
+    else
+      echo "  [DRY RUN] Would delete ${branch} (task ${branch_tail} completed)"
+    fi
+  else
+    echo "  [KEEP]    ${branch}"
+  fi
+done <<< "$all_branches"
+
+echo ""
+if [[ $orphan_count -gt 0 ]]; then
+  if $EXECUTE; then
+    echo "Deleted ${orphan_count} orphan branch(es)."
+  else
+    echo "${orphan_count} orphan branch(es) to clean up. Re-run with --execute to delete."
+  fi
+else
+  echo "No orphan branches found."
+fi

--- a/taskrunner.sh
+++ b/taskrunner.sh
@@ -712,8 +712,11 @@ execute_task() {
         log "│  Ratchet: feature branch '${feature_branch}' exists — suppressing auto-branch creation"
         branch="$feature_branch"
         feature_branch_mode=true
-        git checkout "$feature_branch" 2>/dev/null || \
-          git checkout -b "$feature_branch" "origin/${feature_branch}" 2>/dev/null
+        if ! git checkout "$feature_branch" 2>/dev/null && \
+           ! git checkout -b "$feature_branch" "origin/${feature_branch}" 2>/dev/null; then
+          log "│  ERROR: failed to checkout feature branch '${feature_branch}' — aborting task"
+          return 1
+        fi
         log "│  Branch: ${branch} (existing)"
       fi
     fi

--- a/taskrunner.sh
+++ b/taskrunner.sh
@@ -220,21 +220,20 @@ print("\n".join(lines))
 '
 }
 
-# ─── Ratchet mode (#16) ─────────────────────────────────────
+# ─── Ratchet mode (#16, #26) ────────────────────────────────
 # Measure-before-after validation for autonomous improvements.
 # Captures baseline metrics on main BEFORE the branch exists, re-runs the
 # same checks on the branch AFTER the task commits, and reverts the task
 # (deletes branch, skips push/PR) if metrics regressed.
 #
-# Opt-in paths:
-#   1. Explicit per-task field: `"ratchet": true` in the task JSON
-#   2. Category default: `refactor` and `bugfix` tasks ratchet automatically
-#   3. Environment override: `CC_RATCHET=1` enables for every task
-#      (override with `CC_RATCHET=0`)
+# Ratchet is ACTIVE by default (opt-out). Disable with:
+#   1. Explicit per-task field: `"ratchet": false` in the task JSON
+#   2. Category default: `docs`, `tests`, `research`, `deploy` always skip
+#   3. Environment override: CC_RATCHET=0 or CC_DISABLE_RATCHET=1
 #
-# Categories NEVER ratcheted (signal noise > signal value):
-#   - docs, tests — no regression surface
-#   - research, deploy — outcomes aren't code-level
+# The ratchet also suppresses auto/{category}/{task-id} branch creation
+# when the task declares a `feature_branch` field pointing to an existing
+# branch — the task runs on that branch instead. See #26.
 #
 # Checks captured in the snapshot (each is independent and degrades to
 # `skip` when not applicable to the target repo):
@@ -267,10 +266,11 @@ ratchet_enabled_for_task() {
   if [[ "$explicit" = "true" ]]; then return 0; fi
   if [[ "$explicit" = "false" ]]; then return 1; fi
 
+  # Default: ratchet ON for all categories except signal-only ones.
+  # Opt out per-task with "ratchet": false or globally with CC_RATCHET=0.
   case "$category" in
-    refactor|bugfix) return 0 ;;
     docs|tests|research|deploy) return 1 ;;
-    *) return 1 ;;
+    *) return 0 ;;
   esac
 }
 
@@ -590,13 +590,15 @@ build_claude_cmd() {
 execute_task() {
   local task_json="$1"
 
-  local task_id title repo prompt max_turns authority
+  local task_id title repo prompt max_turns authority category feature_branch
   task_id=$(echo "$task_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
   title=$(echo "$task_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["title"])')
   repo=$(echo "$task_json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("repo", "."))')
   prompt=$(echo "$task_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["prompt"])')
   max_turns=$(echo "$task_json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("max_turns", 25))' 2>/dev/null)
   authority=$(echo "$task_json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("authority", "auto_safe"))' 2>/dev/null)
+  category=$(echo "$task_json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("category", "task"))' 2>/dev/null || echo "task")
+  feature_branch=$(echo "$task_json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("feature_branch", ""))' 2>/dev/null || echo "")
 
   log "┌─ Task: ${title}"
   log "│  ID:   ${task_id:0:8}"
@@ -646,7 +648,7 @@ execute_task() {
   # Non-operator tasks get their own branch
   if [[ "$authority" != "operator" ]]; then
     use_branch=true
-    branch="auto/${task_id:0:8}"
+    branch="auto/${category}/${task_id:0:8}"
 
     # Stash uncommitted TRACKED changes to protect live work.
     #
@@ -692,36 +694,61 @@ execute_task() {
       log "│  Ratchet baseline: ${RATCHET_BASELINE}"
     fi
 
-    # Check both local AND remote refs for existing branch (#14)
-    # Prior bug: only checked local refs, missed remote-only branches left by
-    # worktree cleanup. Those stale remote branches caused push failures.
+    # Fetch to check branch state (used for both feature-branch and auto-branch checks)
     git fetch origin --prune --quiet 2>/dev/null || true
-    local has_local_branch=false has_remote_branch=false
-    git rev-parse --verify "refs/heads/${branch}" >/dev/null 2>&1 && has_local_branch=true
-    git show-ref --verify --quiet "refs/remotes/origin/${branch}" 2>/dev/null && has_remote_branch=true
 
-    if $has_local_branch || $has_remote_branch; then
-      if $has_remote_branch; then
-        # Check if a stale PR is still open — close it
-        if command -v gh >/dev/null 2>&1; then
-          local remote_url_check repo_slug_check pr_state
-          remote_url_check=$(git remote get-url origin 2>/dev/null)
-          repo_slug_check=$(echo "$remote_url_check" | sed -E 's|.*github\.com[:/](.+)(\.git)?$|\1|' | sed 's/\.git$//')
-          pr_state=$(gh pr view "$branch" --repo "$repo_slug_check" --json state --jq .state 2>/dev/null || echo "NONE")
-          if [[ "$pr_state" == "OPEN" ]]; then
-            log "│  Closing stale PR on ${branch} (prior run left it open)"
-            gh pr close "$branch" --repo "$repo_slug_check" --comment "Superseded by task re-run (${task_id})" 2>/dev/null || true
-          fi
-        fi
-        git push origin --delete "$branch" 2>/dev/null || true
+    # ── Feature branch ratchet (#26) ────────────────────────────────────────
+    # When the task declares a feature_branch and ratchet is active, suppress
+    # auto/{category}/{task-id} branch creation and use the existing branch.
+    local feature_branch_mode=false
+    if [[ -n "$feature_branch" ]] && ratchet_enabled_for_task "$task_json"; then
+      local fb_exists=false
+      if git rev-parse --verify "refs/heads/${feature_branch}" >/dev/null 2>&1; then
+        fb_exists=true
+      elif git show-ref --verify --quiet "refs/remotes/origin/${feature_branch}" 2>/dev/null; then
+        fb_exists=true
       fi
-      if $has_local_branch; then
-        git branch -D "$branch" 2>/dev/null || true
+      if $fb_exists; then
+        log "│  Ratchet: feature branch '${feature_branch}' exists — suppressing auto-branch creation"
+        branch="$feature_branch"
+        feature_branch_mode=true
+        git checkout "$feature_branch" 2>/dev/null || \
+          git checkout -b "$feature_branch" "origin/${feature_branch}" 2>/dev/null
+        log "│  Branch: ${branch} (existing)"
       fi
     fi
 
-    git checkout -b "$branch"
-    log "│  Branch: ${branch}"
+    if ! $feature_branch_mode; then
+      # Check both local AND remote refs for existing auto-branch (#14)
+      # Prior bug: only checked local refs, missed remote-only branches left by
+      # worktree cleanup. Those stale remote branches caused push failures.
+      local has_local_branch=false has_remote_branch=false
+      git rev-parse --verify "refs/heads/${branch}" >/dev/null 2>&1 && has_local_branch=true
+      git show-ref --verify --quiet "refs/remotes/origin/${branch}" 2>/dev/null && has_remote_branch=true
+
+      if $has_local_branch || $has_remote_branch; then
+        if $has_remote_branch; then
+          # Check if a stale PR is still open — close it
+          if command -v gh >/dev/null 2>&1; then
+            local remote_url_check repo_slug_check pr_state
+            remote_url_check=$(git remote get-url origin 2>/dev/null)
+            repo_slug_check=$(echo "$remote_url_check" | sed -E 's|.*github\.com[:/](.+)(\.git)?$|\1|' | sed 's/\.git$//')
+            pr_state=$(gh pr view "$branch" --repo "$repo_slug_check" --json state --jq .state 2>/dev/null || echo "NONE")
+            if [[ "$pr_state" == "OPEN" ]]; then
+              log "│  Closing stale PR on ${branch} (prior run left it open)"
+              gh pr close "$branch" --repo "$repo_slug_check" --comment "Superseded by task re-run (${task_id})" 2>/dev/null || true
+            fi
+          fi
+          git push origin --delete "$branch" 2>/dev/null || true
+        fi
+        if $has_local_branch; then
+          git branch -D "$branch" 2>/dev/null || true
+        fi
+      fi
+
+      git checkout -b "$branch"
+      log "│  Branch: ${branch}"
+    fi
 
     # Seed .git/info/exclude to block Windows-path directories that agents
     # sometimes create (e.g. C:\Users\...) which cause git ls-files to hang

--- a/tests/test-branch-lifecycle.sh
+++ b/tests/test-branch-lifecycle.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# tests/test-branch-lifecycle.sh — Branch ratchet lifecycle tests
+#
+# Asserts:
+#   1. ratchet_enabled_for_task returns true by default (opt-out semantics)
+#   2. docs/tests/research/deploy categories are exempt
+#   3. When a feature branch exists for a task, the ratchet suppresses
+#      auto-branch creation (feature_branch_mode=true)
+#   4. When no feature branch exists, auto-branch creation proceeds normally
+#
+# Run: bash tests/test-branch-lifecycle.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TASKRUNNER="${SCRIPT_DIR}/../taskrunner.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; echo "        expected: $2"; echo "        actual:   $3"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then pass "$desc"; else fail "$desc" "$expected" "$actual"; fi
+}
+
+assert_exit() {
+  local desc="$1" want="$2"; shift 2
+  local got=0; "$@" 2>/dev/null || got=$?
+  if [[ "$want" == "$got" ]]; then pass "$desc"; else fail "$desc (exit)" "$want" "$got"; fi
+}
+
+# ── Source ratchet_enabled_for_task from taskrunner.sh ───────────────────────
+# Extract just the function so we don't run the main loop.
+eval "$(awk '/^ratchet_enabled_for_task\(\)/,/^}/' "$TASKRUNNER")"
+
+# ── 1. Default opt-out semantics ─────────────────────────────────────────────
+echo "=== ratchet_enabled_for_task: opt-out defaults ==="
+
+unset CC_RATCHET CC_DISABLE_RATCHET
+
+assert_exit "empty category → ratchet enabled (default ON)" 0 \
+  ratchet_enabled_for_task '{"id":"t1","title":"T","category":""}'
+
+assert_exit "bugfix → ratchet enabled" 0 \
+  ratchet_enabled_for_task '{"id":"t2","title":"T","category":"bugfix"}'
+
+assert_exit "refactor → ratchet enabled" 0 \
+  ratchet_enabled_for_task '{"id":"t3","title":"T","category":"refactor"}'
+
+assert_exit "feature (unknown) → ratchet enabled" 0 \
+  ratchet_enabled_for_task '{"id":"t4","title":"T","category":"feature"}'
+
+assert_exit "docs → ratchet disabled (exempt)" 1 \
+  ratchet_enabled_for_task '{"id":"t5","title":"T","category":"docs"}'
+
+assert_exit "tests → ratchet disabled (exempt)" 1 \
+  ratchet_enabled_for_task '{"id":"t6","title":"T","category":"tests"}'
+
+assert_exit "research → ratchet disabled (exempt)" 1 \
+  ratchet_enabled_for_task '{"id":"t7","title":"T","category":"research"}'
+
+assert_exit "deploy → ratchet disabled (exempt)" 1 \
+  ratchet_enabled_for_task '{"id":"t8","title":"T","category":"deploy"}'
+
+assert_exit 'explicit "ratchet":false overrides bugfix default' 1 \
+  ratchet_enabled_for_task '{"id":"t9","title":"T","category":"bugfix","ratchet":false}'
+
+assert_exit 'explicit "ratchet":true overrides docs exempt' 0 \
+  ratchet_enabled_for_task '{"id":"t10","title":"T","category":"docs","ratchet":true}'
+
+CC_RATCHET=0
+assert_exit "CC_RATCHET=0 disables ratchet globally" 1 \
+  ratchet_enabled_for_task '{"id":"t11","title":"T","category":"bugfix"}'
+unset CC_RATCHET
+
+CC_DISABLE_RATCHET=1
+assert_exit "CC_DISABLE_RATCHET=1 disables ratchet globally" 1 \
+  ratchet_enabled_for_task '{"id":"t12","title":"T","category":"bugfix"}'
+unset CC_DISABLE_RATCHET
+
+echo ""
+
+# ── 2. Feature branch suppression ────────────────────────────────────────────
+# Simulate the check that execute_task() performs without running a full
+# Claude Code session.  The helper mirrors the ratchet branch-suppression
+# logic added in taskrunner.sh.
+
+check_auto_branch_suppressed() {
+  local task_json="$1" repo_path="$2"
+
+  local fb
+  fb=$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("feature_branch",""))' \
+       <<< "$task_json" 2>/dev/null || echo "")
+
+  [[ -z "$fb" ]] && { echo "no_suppression"; return 0; }
+
+  if ! ratchet_enabled_for_task "$task_json" 2>/dev/null; then
+    echo "ratchet_disabled"
+    return 0
+  fi
+
+  if git -C "$repo_path" rev-parse --verify "refs/heads/${fb}" >/dev/null 2>&1 || \
+     git -C "$repo_path" show-ref --verify --quiet "refs/remotes/origin/${fb}" 2>/dev/null; then
+    echo "suppressed"
+  else
+    echo "branch_not_found"
+  fi
+}
+
+echo "=== Feature branch suppression ==="
+
+# Create a temporary git repo with a feature branch
+TMPDIR_REPO=$(mktemp -d)
+# shellcheck disable=SC2064
+trap "rm -rf '$TMPDIR_REPO'" EXIT
+
+(
+  cd "$TMPDIR_REPO"
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  echo "initial" > README.md
+  git add README.md
+  git commit -q -m "initial"
+  git checkout -q -b feature/my-fix
+  echo "fix" > fix.txt
+  git add fix.txt
+  git commit -q -m "fix"
+  git checkout -q main 2>/dev/null || git checkout -q master 2>/dev/null
+)
+
+unset CC_RATCHET CC_DISABLE_RATCHET
+
+result=$(check_auto_branch_suppressed \
+  '{"id":"t20","title":"T","category":"bugfix","feature_branch":"feature/my-fix"}' \
+  "$TMPDIR_REPO")
+assert_eq "feature branch exists → auto-branch suppressed" "suppressed" "$result"
+
+result=$(check_auto_branch_suppressed \
+  '{"id":"t21","title":"T","category":"bugfix"}' \
+  "$TMPDIR_REPO")
+assert_eq "no feature_branch field → auto-branch proceeds normally" "no_suppression" "$result"
+
+result=$(check_auto_branch_suppressed \
+  '{"id":"t22","title":"T","category":"bugfix","feature_branch":"feature/nonexistent"}' \
+  "$TMPDIR_REPO")
+assert_eq "feature_branch field but branch absent → auto-branch proceeds" "branch_not_found" "$result"
+
+result=$(check_auto_branch_suppressed \
+  '{"id":"t23","title":"T","category":"bugfix","feature_branch":"feature/my-fix","ratchet":false}' \
+  "$TMPDIR_REPO")
+assert_eq "ratchet disabled → no suppression even if branch exists" "ratchet_disabled" "$result"
+
+result=$(check_auto_branch_suppressed \
+  '{"id":"t24","title":"T","category":"docs","feature_branch":"feature/my-fix"}' \
+  "$TMPDIR_REPO")
+assert_eq "docs category (exempt) + feature_branch → no suppression" "ratchet_disabled" "$result"
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+[[ $FAIL -eq 0 ]]

--- a/workers-ai/README.md
+++ b/workers-ai/README.md
@@ -8,7 +8,7 @@ Cloudflare Workers AI native executor for cc-taskrunner task queues. Claims and 
 npm install @stackbilt/workers-ai-taskrunner
 ```
 
-Peer dependencies: `@cloudflare/workers-types >=4`, `@stackbilt/llm-providers >=1.16.0`
+Peer dependencies: `@cloudflare/workers-types >=4`, `@stackbilt/llm-providers >=1.18.0`
 
 ## Quick Start
 
@@ -40,7 +40,8 @@ export default {
 
 | Field | Type | Default |
 |-------|------|---------|
-| `model` | `string` | `@cf/meta/llama-4-scout-17b-16e-instruct` |
+| `model` | `string` | `@cf/zai-org/glm-5.2` |
+| `fallbackModel` | `string` | `@cf/meta/llama-4-scout-17b-16e-instruct` |
 | `maxTasksPerRun` | `number` | `3` |
 | `maxResultChars` | `number` | `4000` |
 | `systemPrompt` | `string` | Built-in executor prompt |
@@ -93,7 +94,7 @@ Tasks flow: `pending` → `running` → `completed` | `failed`
 
 ## LLM Routing
 
-All inference goes through `@stackbilt/llm-providers` (`CloudflareProvider`) — no bolted-in `ai.run()` calls. This ensures consistent response normalization, usage tracking, and resiliency across the Stackbilt ecosystem.
+All inference goes through `@stackbilt/llm-providers` (`CloudflareProvider`) — no bolted-in `ai.run()` calls. The default primary model is Workers AI GLM-5.2 (`@cf/zai-org/glm-5.2`), with Llama 4 Scout as the built-in fallback. This ensures consistent response normalization, usage tracking, model catalog validation, and resiliency across the Stackbilt ecosystem.
 
 ## License
 

--- a/workers-ai/dist/executor.js
+++ b/workers-ai/dist/executor.js
@@ -1,5 +1,6 @@
 import { CloudflareProvider } from '@stackbilt/llm-providers';
-const DEFAULT_MODEL = '@cf/meta/llama-4-scout-17b-16e-instruct';
+const DEFAULT_MODEL = '@cf/zai-org/glm-5.2';
+const DEFAULT_FALLBACK_MODEL = '@cf/meta/llama-4-scout-17b-16e-instruct';
 const DEFAULT_MAX_RESULT_CHARS = 4000;
 const DEFAULT_SYSTEM_PROMPT = `You are an autonomous task executor. Complete the assigned task precisely and thoroughly.
 
@@ -8,15 +9,29 @@ If you cannot complete the task (ambiguous instructions, missing context, or out
 Do not ask clarifying questions. Work with what you have.`;
 export async function executeTask(ai, task, options = {}) {
     const model = options.model ?? DEFAULT_MODEL;
+    const fallbackModel = options.fallbackModel ?? DEFAULT_FALLBACK_MODEL;
     const maxChars = options.maxResultChars ?? DEFAULT_MAX_RESULT_CHARS;
     const systemPrompt = options.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;
     const provider = new CloudflareProvider({ ai });
-    const response = await provider.generateResponse({
+    const request = {
         model,
         systemPrompt,
         messages: [{ role: 'user', content: task.prompt }],
         maxTokens: 4096,
-    });
+    };
+    let response;
+    try {
+        response = await provider.generateResponse(request);
+    }
+    catch (err) {
+        if (!fallbackModel || fallbackModel === model) {
+            throw err;
+        }
+        response = await provider.generateResponse({
+            ...request,
+            model: fallbackModel,
+        });
+    }
     const text = response.message ?? '';
     const completionSignal = task.completion_signal ?? 'TASK_COMPLETE';
     // Check only the tail — prevents false positives when model documents the signals

--- a/workers-ai/dist/types.d.ts
+++ b/workers-ai/dist/types.d.ts
@@ -12,9 +12,9 @@ export interface RunnerConfig {
     options?: RunnerOptions;
 }
 export interface RunnerOptions {
-    /** Primary model. Default: '@cf/meta/llama-4-scout-17b-16e-instruct' */
+    /** Primary model. Default: '@cf/zai-org/glm-5.2' */
     model?: string;
-    /** Fallback model if primary fails. Default: '@cf/meta/llama-3.1-70b-instruct' */
+    /** Fallback model if primary fails. Default: '@cf/meta/llama-4-scout-17b-16e-instruct' */
     fallbackModel?: string;
     /** Max tasks to claim and execute per run() call. Default: 3 */
     maxTasksPerRun?: number;

--- a/workers-ai/package-lock.json
+++ b/workers-ai/package-lock.json
@@ -1,22 +1,22 @@
 {
-  "name": "@cc-taskrunner/workers-ai",
+  "name": "@stackbilt/workers-ai-taskrunner",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@cc-taskrunner/workers-ai",
+      "name": "@stackbilt/workers-ai-taskrunner",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250409.0",
-        "@stackbilt/llm-providers": "^1.16.0",
+        "@stackbilt/llm-providers": "^1.18.0",
         "typescript": "^5.0.0",
         "vitest": "^2.0.0"
       },
       "peerDependencies": {
         "@cloudflare/workers-types": ">=4",
-        "@stackbilt/llm-providers": ">=1.16.0"
+        "@stackbilt/llm-providers": ">=1.18.0"
       }
     },
     "node_modules/@cloudflare/workers-types": {
@@ -814,9 +814,9 @@
       ]
     },
     "node_modules/@stackbilt/llm-providers": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@stackbilt/llm-providers/-/llm-providers-1.16.0.tgz",
-      "integrity": "sha512-xgjuQS9A3c+FtZejUNofKI4R/fjnY8rON15I3Dscf0k6V0hdTd/Gw2eHAMRLAuivGNSQu+X0KW4LoWkJzP0rVw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@stackbilt/llm-providers/-/llm-providers-1.18.0.tgz",
+      "integrity": "sha512-EGu3yBoigd44LgVniUoGEjg1eYbr4NprVdj47tj33mfXiLLU1GmOlICWSXwYtpnadWV2qV9AQtAO+oKnmD4Q5Q==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/workers-ai/package.json
+++ b/workers-ai/package.json
@@ -18,13 +18,13 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250409.0",
-    "@stackbilt/llm-providers": "^1.16.0",
+    "@stackbilt/llm-providers": "^1.18.0",
     "typescript": "^5.0.0",
     "vitest": "^2.0.0"
   },
   "peerDependencies": {
     "@cloudflare/workers-types": ">=4",
-    "@stackbilt/llm-providers": ">=1.16.0"
+    "@stackbilt/llm-providers": ">=1.18.0"
   },
   "license": "Apache-2.0"
 }

--- a/workers-ai/src/executor.ts
+++ b/workers-ai/src/executor.ts
@@ -1,7 +1,9 @@
 import { CloudflareProvider } from '@stackbilt/llm-providers';
+import type { LLMRequest, LLMResponse } from '@stackbilt/llm-providers';
 import type { CcTask, RunnerOptions } from './types.js';
 
-const DEFAULT_MODEL = '@cf/meta/llama-4-scout-17b-16e-instruct';
+const DEFAULT_MODEL = '@cf/zai-org/glm-5.2';
+const DEFAULT_FALLBACK_MODEL = '@cf/meta/llama-4-scout-17b-16e-instruct';
 const DEFAULT_MAX_RESULT_CHARS = 4000;
 
 const DEFAULT_SYSTEM_PROMPT = `You are an autonomous task executor. Complete the assigned task precisely and thoroughly.
@@ -22,17 +24,31 @@ export async function executeTask(
   options: RunnerOptions = {},
 ): Promise<ExecutionResult> {
   const model = options.model ?? DEFAULT_MODEL;
+  const fallbackModel = options.fallbackModel ?? DEFAULT_FALLBACK_MODEL;
   const maxChars = options.maxResultChars ?? DEFAULT_MAX_RESULT_CHARS;
   const systemPrompt = options.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;
 
   const provider = new CloudflareProvider({ ai });
 
-  const response = await provider.generateResponse({
+  const request: LLMRequest = {
     model,
     systemPrompt,
     messages: [{ role: 'user', content: task.prompt }],
     maxTokens: 4096,
-  });
+  };
+
+  let response: LLMResponse;
+  try {
+    response = await provider.generateResponse(request);
+  } catch (err) {
+    if (!fallbackModel || fallbackModel === model) {
+      throw err;
+    }
+    response = await provider.generateResponse({
+      ...request,
+      model: fallbackModel,
+    });
+  }
 
   const text = response.message ?? '';
   const completionSignal = task.completion_signal ?? 'TASK_COMPLETE';

--- a/workers-ai/src/index.test.ts
+++ b/workers-ai/src/index.test.ts
@@ -30,9 +30,16 @@ function makeDb(tasks: CcTask[] = []) {
 
 // ─── Minimal Ai mock ─────────────────────────────────────────────────────────
 
-function makeAi(response: string) {
+function makeAi(response: string, options: { failModels?: string[] } = {}) {
+  const failModels = new Set(options.failModels ?? []);
   return {
-    run: vi.fn(async () => ({ response })),
+    run: vi.fn(async (model: string) => {
+      if (failModels.has(model)) {
+        failModels.delete(model);
+        throw new Error(`model unavailable: ${model}`);
+      }
+      return { response };
+    }),
   } as unknown as Ai;
 }
 
@@ -115,5 +122,28 @@ describe('createWorkersAiRunner', () => {
     });
     const result = await runner.run();
     expect(result.processed).toBeLessThanOrEqual(1);
+  });
+
+  it('falls back from GLM-5.2 to Llama 4 Scout when the primary model fails', async () => {
+    const task: CcTask = {
+      id: 'task-005',
+      title: 'Fallback task',
+      repo: 'test-repo',
+      prompt: 'Do something',
+      category: 'research',
+      completion_signal: null,
+    };
+    const ai = makeAi('Fallback result.\nTASK_COMPLETE', {
+      failModels: ['@cf/zai-org/glm-5.2'],
+    });
+    const db = makeDb([task]);
+    const runner = createWorkersAiRunner({ db, ai });
+    const result = await runner.run();
+
+    expect(result.completed).toBe(1);
+    expect((ai.run as unknown as ReturnType<typeof vi.fn>).mock.calls.map(call => call[0])).toEqual([
+      '@cf/zai-org/glm-5.2',
+      '@cf/meta/llama-4-scout-17b-16e-instruct',
+    ]);
   });
 });

--- a/workers-ai/src/types.ts
+++ b/workers-ai/src/types.ts
@@ -14,9 +14,9 @@ export interface RunnerConfig {
 }
 
 export interface RunnerOptions {
-  /** Primary model. Default: '@cf/meta/llama-4-scout-17b-16e-instruct' */
+  /** Primary model. Default: '@cf/zai-org/glm-5.2' */
   model?: string;
-  /** Fallback model if primary fails. Default: '@cf/meta/llama-3.1-70b-instruct' */
+  /** Fallback model if primary fails. Default: '@cf/meta/llama-4-scout-17b-16e-instruct' */
   fallbackModel?: string;
   /** Max tasks to claim and execute per run() call. Default: 3 */
   maxTasksPerRun?: number;


### PR DESCRIPTION
## Summary

- **Ratchet opt-out (#26)**: `ratchet_enabled_for_task()` now defaults ON for all task categories. Previously only `refactor` and `bugfix` were opted in. Exempt categories unchanged: `docs`, `tests`, `research`, `deploy`. Opt out per-task with `"ratchet": false` or globally with `CC_RATCHET=0`.
- **Branch naming**: branches now follow `auto/{category}/{task-id}` (was `auto/{task-id}`).
- **Feature-branch ratchet (#26)**: when a task declares `"feature_branch": "<name>"` and ratchet is active, auto-branch creation is suppressed. The runner checks out the existing feature branch instead of creating a new `auto/` branch.
- **Orphan branch cleanup (#29)**: `scripts/cleanup-branches.sh` lists all `auto/` branches, matches them against completed tasks in `queue.json`, and deletes them. Dry-run by default; pass `--execute` to actually delete. Handles both `auto/{task-id}` (legacy) and `auto/{category}/{task-id}` (current) formats.
- **Tests**: `tests/test-branch-lifecycle.sh` — 17 bash assertions covering opt-out defaults, exempt categories, env-var overrides (`CC_RATCHET`, `CC_DISABLE_RATCHET`), explicit per-task flag overrides, and feature-branch suppression logic.

## Decision record

Decide receipt: `ab24521b05546e7381dfd5a45719bd06e09368335348ba4f52e5d4a6944624fb`

## Test plan

- [x] `bash tests/test-branch-lifecycle.sh` — 17 passed, 0 failed
- [x] `cd workers-ai && npm test` — 7 passed, 0 failed (no regressions)
- [ ] Manual: add a task with `"feature_branch": "feature/my-fix"` to queue.json and verify the runner checks out the existing branch instead of creating `auto/...`
- [ ] Manual: run `./scripts/cleanup-branches.sh` on a repo with completed tasks and verify dry-run output

---
Closes #26, closes #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)