### PR TITLE
feature: D1 fix_queue CLI pull bridge

### DIFF
--- a/scripts/pull-fix.sh
+++ b/scripts/pull-fix.sh
@@ -45,6 +45,8 @@ done
 err() { echo "ERROR: $*" >&2; exit 1; }
 
 [[ -n "$FIX_ID" ]] || err "--fix-id <uuid> is required"
+[[ "$FIX_ID" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]] \
+  || err "invalid UUID format: ${FIX_ID}"
 
 # ─── Validate env ────────────────────────────────────────────
 [[ -n "${CLOUDFLARE_API_TOKEN:-}" ]] || err "CLOUDFLARE_API_TOKEN is not set"
@@ -84,7 +86,8 @@ print(json.dumps({"sql": sys.argv[1], "params": json.loads(sys.argv[2])}))
 echo "Fetching fix ${FIX_ID} from D1 fix_queue ..." >&2
 
 SELECT_SQL="SELECT * FROM fix_queue WHERE id = ? AND fix_tier = 'QUEUED' AND status = 'pending'"
-fetch_resp="$(d1_query "$SELECT_SQL" "$(printf '["%s"]' "$FIX_ID")")"
+SELECT_PARAMS="$(python3 -c 'import json,sys; print(json.dumps([sys.argv[1]]))' "$FIX_ID")"
+fetch_resp="$(d1_query "$SELECT_SQL" "$SELECT_PARAMS")"
 
 # Validate response shape + extract the single row as JSON.
 ROW_JSON="$(python3 -c '
@@ -112,28 +115,11 @@ if $DRY_RUN; then
   exit 0
 fi
 
-# ─── 3. Claim the row (compare-and-set) ──────────────────────
-echo "Claiming fix ${FIX_ID} (status pending → in_progress) ..." >&2
-
-CLAIM_SQL="UPDATE fix_queue SET status = 'in_progress' WHERE id = ? AND status = 'pending'"
-claim_resp="$(d1_query "$CLAIM_SQL" "$(printf '["%s"]' "$FIX_ID")")"
-
-CHANGES="$(python3 -c '
-import json, sys
-resp = json.load(sys.stdin)
-if not resp.get("success", False):
-    sys.stderr.write("D1 claim update unsuccessful: %s\n" % json.dumps(resp.get("errors")))
-    sys.exit(2)
-results = resp.get("result") or []
-meta = results[0].get("meta", {}) if results else {}
-print(meta.get("changes", 0))
-' <<<"$claim_resp")" || exit 1
-
-if [[ "$CHANGES" != "1" ]]; then
-  err "Fix ${FIX_ID} already claimed by another runner (rows changed: ${CHANGES})"
-fi
-
-# ─── 4. Map D1 row → queue.json task and append ──────────────
+# ─── 3. Map D1 row → queue.json task and append ──────────────
+# Append BEFORE claiming in D1: if the append fails (missing repo, dup id,
+# write error), the D1 row is left untouched as 'pending' so another runner
+# can still pick it up. The D1 claim happens only after the local write
+# succeeds, and is rolled back (queue entry removed) if the claim is lost.
 init_queue() {
   [[ -f "$QUEUE_FILE" ]] || echo '[]' > "$QUEUE_FILE"
 }
@@ -150,10 +136,15 @@ created_at = sys.argv[3]
 
 fix_id = row["id"]
 
+repo = row.get("repo")
+if not repo:
+    sys.stderr.write("D1 row %s is missing the required \"repo\" field\n" % fix_id)
+    sys.exit(6)
+
 task = {
     "id": fix_id,
     "title": row.get("title") or f"CodeBeast fix {fix_id[:8]}",
-    "repo": row.get("repo") or ".",
+    "repo": repo,
     "prompt": row.get("prompt") or "",
     "authority": row.get("authority") or "auto_safe",
     "max_turns": int(row.get("max_turns") or 20),
@@ -181,6 +172,46 @@ if any(t.get("id") == fix_id for t in queue):
 queue.append(task)
 with open(queue_file, "w") as f:
     json.dump(queue, f, indent=2)
+' "$ROW_JSON" "$QUEUE_FILE" "$CREATED_AT" || err "failed to append fix ${FIX_ID} to queue.json (D1 row left as pending)"
 
-print("Pulled fix %s: %s -> queue.json" % (fix_id, task["title"]))
-' "$ROW_JSON" "$QUEUE_FILE" "$CREATED_AT"
+# Roll back the queue.json append (used if the D1 claim is lost).
+remove_from_queue() {
+  python3 -c '
+import json, sys
+queue_file, fix_id = sys.argv[1], sys.argv[2]
+with open(queue_file) as f:
+    queue = json.load(f)
+queue = [t for t in queue if t.get("id") != fix_id]
+with open(queue_file, "w") as f:
+    json.dump(queue, f, indent=2)
+' "$QUEUE_FILE" "$FIX_ID" 2>/dev/null || true
+}
+
+# ─── 4. Claim the row in D1 (compare-and-set) ────────────────
+echo "Claiming fix ${FIX_ID} (status pending → in_progress) ..." >&2
+
+CLAIM_SQL="UPDATE fix_queue SET status = 'in_progress' WHERE id = ? AND status = 'pending'"
+PARAMS="$(python3 -c 'import json,sys; print(json.dumps([sys.argv[1]]))' "$FIX_ID")"
+
+if ! claim_resp="$(d1_query "$CLAIM_SQL" "$PARAMS")"; then
+  remove_from_queue
+  err "D1 claim request failed for ${FIX_ID}; rolled back queue.json append"
+fi
+
+CHANGES="$(python3 -c '
+import json, sys
+resp = json.load(sys.stdin)
+if not resp.get("success", False):
+    sys.stderr.write("D1 claim update unsuccessful: %s\n" % json.dumps(resp.get("errors")))
+    sys.exit(2)
+results = resp.get("result") or []
+meta = results[0].get("meta", {}) if results else {}
+print(meta.get("changes", 0))
+' <<<"$claim_resp")" || { remove_from_queue; err "could not parse D1 claim response; rolled back queue.json append"; }
+
+if [[ "$CHANGES" != "1" ]]; then
+  remove_from_queue
+  err "Fix ${FIX_ID} already claimed by another runner (rows changed: ${CHANGES}); rolled back queue.json append"
+fi
+
+echo "Pulled fix ${FIX_ID} → queue.json"

--- a/scripts/pull-fix.sh
+++ b/scripts/pull-fix.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# pull-fix.sh — Bridge CodeBeast D1 fix_queue → cc-taskrunner queue.json
+#
+# Pulls a single approved QUEUED-tier fix from CodeBeast's D1 fix_queue table
+# and appends it to queue.json as a pending task. Claims the D1 row
+# (status pending → in_progress) with a compare-and-set guard so two runners
+# cannot pick up the same fix.
+#
+# Approval is intentionally manual: a human reviews CodeBeast's
+# "AWAITING APPROVAL" comment, then runs this with the fix id.
+#
+# Usage:
+#   scripts/pull-fix.sh --fix-id <uuid>
+#   scripts/pull-fix.sh --fix-id <uuid> --dry-run
+#
+# Required env vars:
+#   CLOUDFLARE_API_TOKEN  — CF API token with D1 read/write
+#   CF_ACCOUNT_ID         — Cloudflare account id
+#   D1_FIX_QUEUE_DB_ID    — D1 database id for the fix_queue DB
+#
+# Optional:
+#   CC_QUEUE_FILE         — override queue.json path
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+QUEUE_FILE="${CC_QUEUE_FILE:-${REPO_DIR}/queue.json}"
+
+# ─── Parse args ──────────────────────────────────────────────
+FIX_ID=""
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fix-id)  FIX_ID="${2:-}"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    -h|--help)
+      grep '^#' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+err() { echo "ERROR: $*" >&2; exit 1; }
+
+[[ -n "$FIX_ID" ]] || err "--fix-id <uuid> is required"
+
+# ─── Validate env ────────────────────────────────────────────
+[[ -n "${CLOUDFLARE_API_TOKEN:-}" ]] || err "CLOUDFLARE_API_TOKEN is not set"
+[[ -n "${CF_ACCOUNT_ID:-}" ]]        || err "CF_ACCOUNT_ID is not set"
+[[ -n "${D1_FIX_QUEUE_DB_ID:-}" ]]   || err "D1_FIX_QUEUE_DB_ID is not set"
+
+command -v curl >/dev/null 2>&1    || err "curl is required"
+command -v python3 >/dev/null 2>&1 || err "python3 is required"
+
+D1_URL="https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/d1/database/${D1_FIX_QUEUE_DB_ID}/query"
+
+# d1_query <sql> <json-array-of-params>
+# Prints the raw response body to stdout; exits non-zero on HTTP/curl failure.
+d1_query() {
+  local sql="$1" params="$2" body http_code response
+
+  body=$(python3 -c '
+import json, sys
+print(json.dumps({"sql": sys.argv[1], "params": json.loads(sys.argv[2])}))
+' "$sql" "$params")
+
+  response=$(curl -sS -w $'\n%{http_code}' -X POST "$D1_URL" \
+    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    --data "$body") || err "D1 request failed (curl)"
+
+  http_code="${response##*$'\n'}"
+  response="${response%$'\n'*}"
+
+  if [[ "$http_code" != "200" ]]; then
+    err "D1 request returned HTTP ${http_code}: ${response}"
+  fi
+  printf '%s' "$response"
+}
+
+# ─── 1. Fetch the fix row ────────────────────────────────────
+echo "Fetching fix ${FIX_ID} from D1 fix_queue ..." >&2
+
+SELECT_SQL="SELECT * FROM fix_queue WHERE id = ? AND fix_tier = 'QUEUED' AND status = 'pending'"
+fetch_resp="$(d1_query "$SELECT_SQL" "$(printf '["%s"]' "$FIX_ID")")"
+
+# Validate response shape + extract the single row as JSON.
+ROW_JSON="$(python3 -c '
+import json, sys
+resp = json.load(sys.stdin)
+if not resp.get("success", False):
+    errs = resp.get("errors") or [{"message": "unknown error"}]
+    sys.stderr.write("D1 query unsuccessful: %s\n" % json.dumps(errs))
+    sys.exit(2)
+results = resp.get("result") or []
+rows = results[0].get("results", []) if results else []
+if len(rows) == 0:
+    sys.stderr.write("No QUEUED/pending fix found for id %s (already claimed, wrong tier, or nonexistent)\n" % sys.argv[1])
+    sys.exit(3)
+if len(rows) > 1:
+    sys.stderr.write("Expected 1 row, got %d for id %s\n" % (len(rows), sys.argv[1]))
+    sys.exit(4)
+print(json.dumps(rows[0]))
+' "$FIX_ID" <<<"$fetch_resp")" || exit 1
+
+# ─── 2. Dry run: print and exit without mutating anything ────
+if $DRY_RUN; then
+  echo "[dry-run] Would pull this fix (no D1 or queue.json changes):" >&2
+  python3 -c 'import json,sys; print(json.dumps(json.loads(sys.argv[1]), indent=2))' "$ROW_JSON"
+  exit 0
+fi
+
+# ─── 3. Claim the row (compare-and-set) ──────────────────────
+echo "Claiming fix ${FIX_ID} (status pending → in_progress) ..." >&2
+
+CLAIM_SQL="UPDATE fix_queue SET status = 'in_progress' WHERE id = ? AND status = 'pending'"
+claim_resp="$(d1_query "$CLAIM_SQL" "$(printf '["%s"]' "$FIX_ID")")"
+
+CHANGES="$(python3 -c '
+import json, sys
+resp = json.load(sys.stdin)
+if not resp.get("success", False):
+    sys.stderr.write("D1 claim update unsuccessful: %s\n" % json.dumps(resp.get("errors")))
+    sys.exit(2)
+results = resp.get("result") or []
+meta = results[0].get("meta", {}) if results else {}
+print(meta.get("changes", 0))
+' <<<"$claim_resp")" || exit 1
+
+if [[ "$CHANGES" != "1" ]]; then
+  err "Fix ${FIX_ID} already claimed by another runner (rows changed: ${CHANGES})"
+fi
+
+# ─── 4. Map D1 row → queue.json task and append ──────────────
+init_queue() {
+  [[ -f "$QUEUE_FILE" ]] || echo '[]' > "$QUEUE_FILE"
+}
+init_queue
+
+CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+python3 -c '
+import json, sys
+
+row = json.loads(sys.argv[1])
+queue_file = sys.argv[2]
+created_at = sys.argv[3]
+
+fix_id = row["id"]
+
+task = {
+    "id": fix_id,
+    "title": row.get("title") or f"CodeBeast fix {fix_id[:8]}",
+    "repo": row.get("repo") or ".",
+    "prompt": row.get("prompt") or "",
+    "authority": row.get("authority") or "auto_safe",
+    "max_turns": int(row.get("max_turns") or 20),
+    "status": "pending",
+    "created_at": created_at,
+    "origin": "d1_fix_queue",
+    "fix_queue_id": fix_id,
+}
+
+# Optional pass-through fields for branch base / tracing.
+if row.get("origin_branch"):
+    task["feature_branch"] = row["origin_branch"]
+if row.get("issue_url"):
+    task["issue_url"] = row["issue_url"]
+if row.get("correlation_id"):
+    task["correlation_id"] = row["correlation_id"]
+
+with open(queue_file) as f:
+    queue = json.load(f)
+
+if any(t.get("id") == fix_id for t in queue):
+    sys.stderr.write(f"Fix {fix_id} already present in queue.json — not appending duplicate.\n")
+    sys.exit(5)
+
+queue.append(task)
+with open(queue_file, "w") as f:
+    json.dump(queue, f, indent=2)
+
+print("Pulled fix %s: %s -> queue.json" % (fix_id, task["title"]))
+' "$ROW_JSON" "$QUEUE_FILE" "$CREATED_AT"

--- a/taskrunner.sh
+++ b/taskrunner.sh
@@ -81,6 +81,7 @@ while [[ $# -gt 0 ]]; do
     --dry-run) DRY_RUN=true; shift ;;
     --turns)   MAX_TURNS="$2"; shift 2 ;;
     add)       ACTION="add"; shift; break ;;
+    pull)      ACTION="pull"; shift; break ;;
     list)      ACTION="list"; shift ;;
     *)         echo "Unknown arg: $1" >&2; exit 1 ;;
   esac
@@ -1168,6 +1169,10 @@ ${result_text}"
 if [[ "$ACTION" == "add" ]]; then
   add_task "$*"
   exit 0
+fi
+
+if [[ "$ACTION" == "pull" ]]; then
+  exec "${SCRIPT_DIR}/scripts/pull-fix.sh" "$@"
 fi
 
 if [[ "$ACTION" == "list" ]]; then


### PR DESCRIPTION
Closes #28

Adds `scripts/pull-fix.sh` and a `pull` subcommand to `taskrunner.sh` that bridge CodeBeast's D1 `fix_queue` into `queue.json`.

## Features
- Fetches a single QUEUED/pending fix from CodeBeast D1 by UUID via the CF D1 REST API
- CAS update (status `pending` → `in_progress`) prevents double-pickup; verified via `meta.changes == 1`
- Respects `--dry-run` (prints the row, mutates nothing in D1 or queue.json)
- Maps D1 fields to the queue.json schema per the issue's mapping table:
  - `id`→`id`, `title`→`title`, `prompt`→`prompt`, `authority`→`authority`, `max_turns`→`max_turns`, `repo`→`repo`
  - optional passthrough: `origin_branch`→`feature_branch`, `issue_url`, `correlation_id`
  - adds `origin: "d1_fix_queue"` and `fix_queue_id` for traceability; `status` always `pending`
- Excludes CLOUD tier (SELECT filters `fix_tier = 'QUEUED'`)
- Credentials and DB id via env vars only — `CLOUDFLARE_API_TOKEN`, `CF_ACCOUNT_ID`, `D1_FIX_QUEUE_DB_ID` (no hardcoded IDs)
- Idempotency: skips appending if the fix id already exists in queue.json

## Usage
```
./taskrunner.sh pull --fix-id <uuid>
./taskrunner.sh pull --fix-id <uuid> --dry-run
```

## Testing
Validated end-to-end against a local mock D1 server: dry-run (no mutation), real pull (claim + append), duplicate-in-queue guard, not-found, and already-claimed (CAS=0) paths. `bash -n` passes on both files.

Implemented via constellation-loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)